### PR TITLE
Install openssh-client in Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM gliderlabs/alpine
 MAINTAINER Tim Lucas <tim@buildkite.com>
 
-RUN apk --update add curl wget bash git
+RUN apk --update add curl wget bash git openssh-client
 
 RUN curl -L https://github.com/docker/compose/releases/download/1.2.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
This is required by [bootstrap.sh:197](https://github.com/buildkite/agent/blob/ea4a967b8174d050295d7eab5539aabbfd3e711e/templates/bootstrap.sh#L197).
