### PR TITLE
Added a docker-in-docker image

### DIFF
--- a/dind/Dockerfile
+++ b/dind/Dockerfile
@@ -1,0 +1,15 @@
+FROM jpetazzo/dind
+MAINTAINER Lachlan Donald <lachlan@99designs.com>
+
+RUN apt-get install -y curl openssh-client git && \
+    curl -L https://github.com/docker/compose/releases/download/1.2.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/docker-compose && \
+    BETA="true" DESTINATION=/buildkite bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
+
+ENV PATH=$PATH:/buildkite/bin \
+    BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
+    BUILDKITE_BUILD_PATH=/buildkite/builds \
+    BUILDKITE_HOOKS_PATH=/buildkite/hooks
+
+ENTRYPOINT ["wrapdocker","buildkite-agent"]
+CMD ["start"]


### PR DESCRIPTION
After running into issues with the conventional "pass in the docker socket" approach to containerized builds, I thought I'd give docker-in-docker a go.

It actually seems to work well, and is simpler from a configuration (and comprehension) point of view.

Some more research is required to understand exactly what dragons are hiding in the dind approach.
