### PR TITLE
build the beta agent by reinstalling over the top of latest

### DIFF
--- a/beta/Dockerfile
+++ b/beta/Dockerfile
@@ -1,0 +1,4 @@
+FROM buildkite/agent
+MAINTAINER Tim Lucas <tim@buildkite.com>
+
+RUN DESTINATION=/buildkite BETA=true bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"

--- a/ubuntu-beta/Dockerfile
+++ b/ubuntu-beta/Dockerfile
@@ -1,0 +1,4 @@
+FROM buildkite/agent:ubuntu
+MAINTAINER Tim Lucas <tim@buildkite.com>
+
+RUN DESTINATION=/buildkite BETA=true bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"


### PR DESCRIPTION
I thought the reinstall approach would be easier to maintain than copying 100% of the root Dockerfile and adding `beta=true`

It does cost an extra 5Mb for another layer, but I think the tradeoff is worth it.
