### PR TITLE
Switch to standard Ubuntu packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* *2015-10-21 (all)*<br>Upgraded docker-compose from 1.4.1 to 1.4.2
+* *2015-10-21 (dind and ubuntu)*<br>Switched to standard buildkite-agent Ubuntu installer (the paths to builds and hooks remain unchanged)
+* *2015-10-21 (dind)*<br>Added beta and experimental dind images.
+* *2015-10-21 (ubuntu)*<br>Added an ubuntu experimental image.
 * *2015-07-08 (latest)*<br>Added Docker 1.8 to dind images
 * *2015-07-08 (latest)*<br>Updated to Docker Compose 1.4.1
 * *2015-07-08 (all)*<br>Switched from beta to stable versions of buildkite-agent

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,10 @@ FROM gliderlabs/alpine:3.1
 MAINTAINER Tim Lucas <tim@buildkite.com>
 
 RUN apk --update add curl wget bash git perl openssh-client && \
-    curl -L https://github.com/docker/compose/releases/download/1.4.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
-    chmod +x /usr/local/bin/docker-compose && \
-    DESTINATION=/buildkite bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
+    curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/docker-compose
+
+RUN DESTINATION=/buildkite bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
 
 ENV PATH=$PATH:/buildkite/bin \
     BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \

--- a/beta/Dockerfile
+++ b/beta/Dockerfile
@@ -1,4 +1,16 @@
-FROM buildkite/agent
+FROM gliderlabs/alpine:3.1
 MAINTAINER Tim Lucas <tim@buildkite.com>
 
+RUN apk --update add curl wget bash git perl openssh-client && \
+    curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/docker-compose
+
 RUN DESTINATION=/buildkite BETA=true bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
+
+ENV PATH=$PATH:/buildkite/bin \
+    BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
+    BUILDKITE_BUILD_PATH=/buildkite/builds \
+    BUILDKITE_HOOKS_PATH=/buildkite/hooks
+
+ENTRYPOINT ["buildkite-agent"]
+CMD ["start"]

--- a/beta/test.sh
+++ b/beta/test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eu
+
+docker build --tag "buildkite-agent-test:beta" .
+
+docker run -it --rm=true "buildkite-agent-test:beta" --version
+
+echo -e "\033[33;32mLooks good!\033[0m"

--- a/dind/1.6.2/Dockerfile
+++ b/dind/1.6.2/Dockerfile
@@ -11,12 +11,20 @@ RUN apt-get update -qq && apt-get install -qqy \
     openssh-client \
     git
 
-# Install Docker & Buildkite
+# Install Docker
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9 && \
     echo 'deb https://get.docker.com/ubuntu docker main' > /etc/apt/sources.list.d/docker.list && \
     apt-get update -q && \
-    apt-get install -q -y lxc-docker-1.6.2 && \
-    DESTINATION=/buildkite bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
+    apt-get install -q -y lxc-docker-1.6.2
+
+# Install Buildkite
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
+    echo 'deb https://apt.buildkite.com/buildkite-agent stable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
+    apt-get update -qq && \
+    apt-get install -qqy buildkite-agent && \
+    mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins && \
+    # Copy the bootstrap to /buildkite in case that's what people were expecting
+    cp /usr/share/buildkite-agent/bootstrap.sh /buildkite/bootstrap.sh
 
 # Install the magic wrapper
 ADD https://raw.githubusercontent.com/jpetazzo/dind/master/wrapdocker /usr/local/bin/wrapdocker
@@ -26,8 +34,7 @@ RUN chmod +x /usr/local/bin/wrapdocker
 RUN curl -L https://github.com/docker/compose/releases/download/1.3.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-ENV PATH=$PATH:/buildkite/bin \
-    BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
+ENV BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
     BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks
 

--- a/dind/1.6.2/Dockerfile
+++ b/dind/1.6.2/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:14.04
+MAINTAINER Tim Lucas <tim@buildkite.com>
 
-# Let's start with some basic stuff.
+# Install the essentials needed to add more apt repos, and any others
 RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
@@ -10,23 +11,20 @@ RUN apt-get update -qq && apt-get install -qqy \
     openssh-client \
     git
 
-# Install Docker
+# Install Docker & Buildkite
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9 && \
     echo 'deb https://get.docker.com/ubuntu docker main' > /etc/apt/sources.list.d/docker.list && \
     apt-get update -q && \
-    apt-get install -q -y lxc-docker-1.6.2
+    apt-get install -q -y lxc-docker-1.6.2 && \
+    DESTINATION=/buildkite bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
 
-# Install the magic wrapper.
+# Install the magic wrapper
 ADD https://raw.githubusercontent.com/jpetazzo/dind/master/wrapdocker /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
 
 # Install Docker Compose
 RUN curl -L https://github.com/docker/compose/releases/download/1.3.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
-
-# Install Buildkite
-RUN DESTINATION=/buildkite bash -c \
-    "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
 
 ENV PATH=$PATH:/buildkite/bin \
     BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \

--- a/dind/1.6.2/test.sh
+++ b/dind/1.6.2/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+tag="buildkite-agent-test:dind-1.6.2"
+
+docker build --tag "$tag" .
+docker run -it --rm=true --privileged=true "$tag" --version
+
+echo -e "\033[33;32mLooks good!\033[0m"

--- a/dind/1.7.0/Dockerfile
+++ b/dind/1.7.0/Dockerfile
@@ -11,12 +11,20 @@ RUN apt-get update -qq && apt-get install -qqy \
     openssh-client \
     git
 
-# Install Docker & Buildkite
+# Install Docker
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9 && \
     echo 'deb https://get.docker.com/ubuntu docker main' > /etc/apt/sources.list.d/docker.list && \
     apt-get update -q && \
-    apt-get install -q -y lxc-docker-1.7.0 && \
-    DESTINATION=/buildkite bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
+    apt-get install -q -y lxc-docker-1.7.0
+
+# Install Buildkite
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
+    echo 'deb https://apt.buildkite.com/buildkite-agent stable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
+    apt-get update -qq && \
+    apt-get install -qqy buildkite-agent && \
+    mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins && \
+    # Copy the bootstrap to /buildkite in case that's what people were expecting
+    cp /usr/share/buildkite-agent/bootstrap.sh /buildkite/bootstrap.sh
 
 # Install the magic wrapper
 ADD https://raw.githubusercontent.com/jpetazzo/dind/master/wrapdocker /usr/local/bin/wrapdocker
@@ -26,8 +34,7 @@ RUN chmod +x /usr/local/bin/wrapdocker
 RUN curl -L https://github.com/docker/compose/releases/download/1.3.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-ENV PATH=$PATH:/buildkite/bin \
-    BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
+ENV BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
     BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks
 

--- a/dind/1.7.0/Dockerfile
+++ b/dind/1.7.0/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:14.04
+MAINTAINER Tim Lucas <tim@buildkite.com>
 
-# Let's start with some basic stuff.
+# Install the essentials needed to add more apt repos, and any others
 RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
@@ -10,23 +11,20 @@ RUN apt-get update -qq && apt-get install -qqy \
     openssh-client \
     git
 
-# Install Docker
+# Install Docker & Buildkite
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9 && \
     echo 'deb https://get.docker.com/ubuntu docker main' > /etc/apt/sources.list.d/docker.list && \
     apt-get update -q && \
-    apt-get install -q -y lxc-docker-1.7.0
+    apt-get install -q -y lxc-docker-1.7.0 && \
+    DESTINATION=/buildkite bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
 
-# Install the magic wrapper.
+# Install the magic wrapper
 ADD https://raw.githubusercontent.com/jpetazzo/dind/master/wrapdocker /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
 
 # Install Docker Compose
 RUN curl -L https://github.com/docker/compose/releases/download/1.3.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
-
-# Install Buildkite
-RUN DESTINATION=/buildkite bash -c \
-    "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
 
 ENV PATH=$PATH:/buildkite/bin \
     BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \

--- a/dind/1.7.0/test.sh
+++ b/dind/1.7.0/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+tag="buildkite-agent-test:dind-1.7.0"
+
+docker build --tag "$tag" .
+docker run -it --rm=true --privileged=true "$tag" --version
+
+echo -e "\033[33;32mLooks good!\033[0m"

--- a/dind/1.7.1/Dockerfile
+++ b/dind/1.7.1/Dockerfile
@@ -10,12 +10,20 @@ RUN apt-get update -qq && apt-get install -qqy \
     openssh-client \
     git
 
-# Install Docker & Buildkite
+# Install Docker
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
     echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
     apt-get update -q && \
-    apt-get install -q -y docker-engine=1.7.1-0~trusty && \
-    DESTINATION=/buildkite bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
+    apt-get install -q -y docker-engine=1.7.1-0~trusty
+
+# Install Buildkite
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
+    echo 'deb https://apt.buildkite.com/buildkite-agent stable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
+    apt-get update -qq && \
+    apt-get install -qqy buildkite-agent && \
+    mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins && \
+    # Copy the bootstrap to /buildkite in case that's what people were expecting
+    cp /usr/share/buildkite-agent/bootstrap.sh /buildkite/bootstrap.sh
 
 # Install the magic wrapper
 ADD https://raw.githubusercontent.com/docker/docker/v1.7.1/hack/dind /usr/local/bin/wrapdocker
@@ -25,8 +33,7 @@ RUN chmod +x /usr/local/bin/wrapdocker
 RUN curl -L https://github.com/docker/compose/releases/download/1.4.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-ENV PATH=$PATH:/buildkite/bin \
-    BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
+ENV BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
     BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks
 

--- a/dind/1.7.1/Dockerfile
+++ b/dind/1.7.1/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:14.04
+MAINTAINER Tim Lucas <tim@buildkite.com>
 
-# Let's start with some basic stuff.
+# Install the essentials needed to add more apt repos, and any others
 RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
@@ -9,23 +10,20 @@ RUN apt-get update -qq && apt-get install -qqy \
     openssh-client \
     git
 
-# Install Docker
+# Install Docker & Buildkite
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
     echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
     apt-get update -q && \
-    apt-get install -q -y docker-engine=1.7.1-0~trusty
+    apt-get install -q -y docker-engine=1.7.1-0~trusty && \
+    DESTINATION=/buildkite bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
 
-# Install the magic wrapper.
+# Install the magic wrapper
 ADD https://raw.githubusercontent.com/docker/docker/v1.7.1/hack/dind /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
 
 # Install Docker Compose
 RUN curl -L https://github.com/docker/compose/releases/download/1.4.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
-
-# Install Buildkite
-RUN DESTINATION=/buildkite bash -c \
-    "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
 
 ENV PATH=$PATH:/buildkite/bin \
     BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \

--- a/dind/1.7.1/test.sh
+++ b/dind/1.7.1/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+tag="buildkite-agent-test:dind-1.7.1"
+
+docker build --tag "$tag" .
+docker run -it --rm=true --privileged=true "$tag" --version
+
+echo -e "\033[33;32mLooks good!\033[0m"

--- a/dind/1.8.2/Dockerfile
+++ b/dind/1.8.2/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:14.04
+MAINTAINER Tim Lucas <tim@buildkite.com>
 
-# Let's start with some basic stuff.
+# Install the essentials needed to add more apt repos, and any others
 RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
@@ -9,23 +10,20 @@ RUN apt-get update -qq && apt-get install -qqy \
     openssh-client \
     git
 
-# Install Docker
+# Install Docker & Buildkite
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
     echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
     apt-get update -q && \
-    apt-get install -q -y docker-engine=1.8.2-0~trusty
+    apt-get install -q -y docker-engine=1.8.2-0~trusty && \
+    DESTINATION=/buildkite bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
 
-# Install the magic wrapper.
+# Install the magic wrapper
 ADD https://raw.githubusercontent.com/docker/docker/v1.8.2/hack/dind /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
 
 # Install Docker Compose
 RUN curl -L https://github.com/docker/compose/releases/download/1.4.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
-
-# Install Buildkite
-RUN DESTINATION=/buildkite bash -c \
-    "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
 
 ENV PATH=$PATH:/buildkite/bin \
     BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \

--- a/dind/1.8.2/Dockerfile
+++ b/dind/1.8.2/Dockerfile
@@ -10,12 +10,20 @@ RUN apt-get update -qq && apt-get install -qqy \
     openssh-client \
     git
 
-# Install Docker & Buildkite
+# Install Docker
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
     echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
     apt-get update -q && \
-    apt-get install -q -y docker-engine=1.8.2-0~trusty && \
-    DESTINATION=/buildkite bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
+    apt-get install -q -y docker-engine=1.8.2-0~trusty
+
+# Install Buildkite
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
+    echo 'deb https://apt.buildkite.com/buildkite-agent stable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
+    apt-get update -qq && \
+    apt-get install -qqy buildkite-agent && \
+    mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins && \
+    # Copy the bootstrap to /buildkite in case that's what people were expecting
+    cp /usr/share/buildkite-agent/bootstrap.sh /buildkite/bootstrap.sh
 
 # Install the magic wrapper
 ADD https://raw.githubusercontent.com/docker/docker/v1.8.2/hack/dind /usr/local/bin/wrapdocker
@@ -25,8 +33,7 @@ RUN chmod +x /usr/local/bin/wrapdocker
 RUN curl -L https://github.com/docker/compose/releases/download/1.4.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-ENV PATH=$PATH:/buildkite/bin \
-    BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
+ENV BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
     BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks
 

--- a/dind/1.8.2/test.sh
+++ b/dind/1.8.2/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+tag="buildkite-agent-test:dind-1.8.2"
+
+docker build --tag "$tag" .
+docker run -it --rm=true --privileged=true "$tag" --version
+
+echo -e "\033[33;32mLooks good!\033[0m"

--- a/dind/beta/1.7.1/Dockerfile
+++ b/dind/beta/1.7.1/Dockerfile
@@ -11,10 +11,14 @@ RUN apt-get update -qq && apt-get install -qqy \
     git
 
 # Install Docker & Buildkite
+#
+# The buildkite-agent apt source points to 'stable' instead of 'unstable'
+# because unstable is currently broken, and there's no other unstable releases
+# since v2.1.4
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
     echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
-    echo 'deb https://apt.buildkite.com/buildkite-agent unstable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
+    echo 'deb https://apt.buildkite.com/buildkite-agent stable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
     apt-get install -qqy docker-engine=1.7.1-0~trusty \
                          buildkite-agent && \

--- a/dind/beta/1.7.1/Dockerfile
+++ b/dind/beta/1.7.1/Dockerfile
@@ -10,14 +10,17 @@ RUN apt-get update -qq && apt-get install -qqy \
     openssh-client \
     git
 
-# Install Docker & Buildkite
+# Install Docker
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
     echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
+    apt-get update -qq && \
+    apt-get install -qqy docker-engine=1.7.1-0~trusty
+
+# Install Buildkite
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
     echo 'deb https://apt.buildkite.com/buildkite-agent unstable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
-    apt-get install -qqy docker-engine=1.7.1-0~trusty \
-                         buildkite-agent && \
+    apt-get install -qqy buildkite-agent && \
     mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
 
 # Install the magic wrapper

--- a/dind/beta/1.7.1/Dockerfile
+++ b/dind/beta/1.7.1/Dockerfile
@@ -1,11 +1,12 @@
 FROM ubuntu:14.04
+MAINTAINER Tim Lucas <tim@buildkite.com>
 
-# Let's start with some basic stuff.
+# Install the essentials needed to add more apt repos, and any others
 RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
-    iptables \
     curl \
+    iptables \
     openssh-client \
     git
 
@@ -13,12 +14,13 @@ RUN apt-get update -qq && apt-get install -qqy \
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
     echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
-    echo 'deb https://apt.buildkite.com/buildkite-agent beta main' > /etc/apt/sources.list.d/buildkite-agent.list && \
+    echo 'deb https://apt.buildkite.com/buildkite-agent unstable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
     apt-get install -qqy docker-engine=1.7.1-0~trusty \
-                         buildkite-agent
+                         buildkite-agent && \
+    mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
 
-# Install the magic wrapper.
+# Install the magic wrapper
 ADD https://raw.githubusercontent.com/docker/docker/v1.7.1/hack/dind /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
 
@@ -26,11 +28,9 @@ RUN chmod +x /usr/local/bin/wrapdocker
 RUN curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-RUN mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
-
 ENV BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks \
-    BUILDKITE_HOOKS_PATH=/buildkite/plugins
+    BUILDKITE_PLUGINS_PATH=/buildkite/plugins
 
 # Internal docker runs out of a volume
 VOLUME /var/lib/docker

--- a/dind/beta/1.7.1/Dockerfile
+++ b/dind/beta/1.7.1/Dockerfile
@@ -11,14 +11,10 @@ RUN apt-get update -qq && apt-get install -qqy \
     git
 
 # Install Docker & Buildkite
-#
-# The buildkite-agent apt source points to 'stable' instead of 'unstable'
-# because unstable is currently broken, and there's no other unstable releases
-# since v2.1.4
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
     echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
-    echo 'deb https://apt.buildkite.com/buildkite-agent stable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
+    echo 'deb https://apt.buildkite.com/buildkite-agent unstable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
     apt-get install -qqy docker-engine=1.7.1-0~trusty \
                          buildkite-agent && \

--- a/dind/beta/1.7.1/test.sh
+++ b/dind/beta/1.7.1/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+tag="buildkite-agent-test:dind-beta-1.7.1"
+
+docker build --tag "$tag" .
+docker run -it --rm=true --privileged=true "$tag" --version
+
+echo -e "\033[33;32mLooks good!\033[0m"

--- a/dind/beta/1.8.2/Dockerfile
+++ b/dind/beta/1.8.2/Dockerfile
@@ -11,10 +11,14 @@ RUN apt-get update -qq && apt-get install -qqy \
     git
 
 # Install Docker & Buildkite
+#
+# The buildkite-agent apt source points to 'stable' instead of 'unstable'
+# because unstable is currently broken, and there's no other unstable releases
+# since v2.1.4
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
     echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
-    echo 'deb https://apt.buildkite.com/buildkite-agent unstable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
+    echo 'deb https://apt.buildkite.com/buildkite-agent stable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
     apt-get install -qqy docker-engine=1.8.2-0~trusty \
                          buildkite-agent && \

--- a/dind/beta/1.8.2/Dockerfile
+++ b/dind/beta/1.8.2/Dockerfile
@@ -10,14 +10,17 @@ RUN apt-get update -qq && apt-get install -qqy \
     openssh-client \
     git
 
-# Install Docker & Buildkite
+# Install Docker
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
     echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
+    apt-get update -qq && \
+    apt-get install -qqy docker-engine=1.8.2-0~trusty
+
+# Install Buildkite
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
     echo 'deb https://apt.buildkite.com/buildkite-agent unstable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
-    apt-get install -qqy docker-engine=1.8.2-0~trusty \
-                         buildkite-agent && \
+    apt-get install -qqy buildkite-agent && \
     mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
 
 # Install the magic wrapper

--- a/dind/beta/1.8.2/Dockerfile
+++ b/dind/beta/1.8.2/Dockerfile
@@ -1,11 +1,12 @@
 FROM ubuntu:14.04
+MAINTAINER Tim Lucas <tim@buildkite.com>
 
-# Let's start with some basic stuff.
+# Install the essentials needed to add more apt repos, and any others
 RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
-    iptables \
     curl \
+    iptables \
     openssh-client \
     git
 
@@ -13,12 +14,13 @@ RUN apt-get update -qq && apt-get install -qqy \
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
     echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
-    echo 'deb https://apt.buildkite.com/buildkite-agent beta main' > /etc/apt/sources.list.d/buildkite-agent.list && \
+    echo 'deb https://apt.buildkite.com/buildkite-agent unstable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
     apt-get install -qqy docker-engine=1.8.2-0~trusty \
-                         buildkite-agent
+                         buildkite-agent && \
+    mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
 
-# Install the magic wrapper.
+# Install the magic wrapper
 ADD https://raw.githubusercontent.com/docker/docker/v1.8.2/hack/dind /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
 
@@ -26,11 +28,9 @@ RUN chmod +x /usr/local/bin/wrapdocker
 RUN curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-RUN mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
-
 ENV BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks \
-    BUILDKITE_HOOKS_PATH=/buildkite/plugins
+    BUILDKITE_PLUGINS_PATH=/buildkite/plugins
 
 # Internal docker runs out of a volume
 VOLUME /var/lib/docker

--- a/dind/beta/1.8.2/Dockerfile
+++ b/dind/beta/1.8.2/Dockerfile
@@ -11,14 +11,10 @@ RUN apt-get update -qq && apt-get install -qqy \
     git
 
 # Install Docker & Buildkite
-#
-# The buildkite-agent apt source points to 'stable' instead of 'unstable'
-# because unstable is currently broken, and there's no other unstable releases
-# since v2.1.4
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
     echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
-    echo 'deb https://apt.buildkite.com/buildkite-agent stable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
+    echo 'deb https://apt.buildkite.com/buildkite-agent unstable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
     apt-get install -qqy docker-engine=1.8.2-0~trusty \
                          buildkite-agent && \

--- a/dind/beta/1.8.2/test.sh
+++ b/dind/beta/1.8.2/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+tag="buildkite-agent-test:dind-beta-1.8.2"
+
+docker build --tag "$tag" .
+docker run -it --rm=true --privileged=true "$tag" --version
+
+echo -e "\033[33;32mLooks good!\033[0m"

--- a/dind/experimental/1.7.1/Dockerfile
+++ b/dind/experimental/1.7.1/Dockerfile
@@ -1,11 +1,12 @@
 FROM ubuntu:14.04
+MAINTAINER Tim Lucas <tim@buildkite.com>
 
-# Let's start with some basic stuff.
+# Install the essentials needed to add more apt repos, and any others
 RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
-    iptables \
     curl \
+    iptables \
     openssh-client \
     git
 
@@ -15,10 +16,11 @@ RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 581
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
     echo 'deb https://apt.buildkite.com/buildkite-agent experimental main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
-    apt-get install -qqy docker-engine=1.8.2-0~trusty \
-                         buildkite-agent
+    apt-get install -qqy docker-engine=1.7.1-0~trusty \
+                         buildkite-agent && \
+    mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
 
-# Install the magic wrapper.
+# Install the magic wrapper
 ADD https://raw.githubusercontent.com/docker/docker/v1.7.1/hack/dind /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
 
@@ -26,11 +28,9 @@ RUN chmod +x /usr/local/bin/wrapdocker
 RUN curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-RUN mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
-
 ENV BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks \
-    BUILDKITE_HOOKS_PATH=/buildkite/plugins
+    BUILDKITE_PLUGINS_PATH=/buildkite/plugins
 
 # Internal docker runs out of a volume
 VOLUME /var/lib/docker

--- a/dind/experimental/1.7.1/Dockerfile
+++ b/dind/experimental/1.7.1/Dockerfile
@@ -10,14 +10,17 @@ RUN apt-get update -qq && apt-get install -qqy \
     openssh-client \
     git
 
-# Install Docker & Buildkite
+# Install Docker
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
     echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
+    apt-get update -qq && \
+    apt-get install -qqy docker-engine=1.7.1-0~trusty
+
+# Install Buildkite
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
     echo 'deb https://apt.buildkite.com/buildkite-agent experimental main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
-    apt-get install -qqy docker-engine=1.7.1-0~trusty \
-                         buildkite-agent && \
+    apt-get install -qqy buildkite-agent && \
     mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
 
 # Install the magic wrapper

--- a/dind/experimental/1.7.1/test.sh
+++ b/dind/experimental/1.7.1/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+tag="buildkite-agent-test:dind-experimental-1.7.1"
+
+docker build --tag "$tag" .
+docker run -it --rm=true --privileged=true "$tag" --version
+
+echo -e "\033[33;32mLooks good!\033[0m"

--- a/dind/experimental/1.8.2/Dockerfile
+++ b/dind/experimental/1.8.2/Dockerfile
@@ -1,11 +1,12 @@
 FROM ubuntu:14.04
+MAINTAINER Tim Lucas <tim@buildkite.com>
 
-# Let's start with some basic stuff.
+# Install the essentials needed to add more apt repos, and any others
 RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
-    iptables \
     curl \
+    iptables \
     openssh-client \
     git
 
@@ -16,9 +17,10 @@ RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 581
     echo 'deb https://apt.buildkite.com/buildkite-agent experimental main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
     apt-get install -qqy docker-engine=1.8.2-0~trusty \
-                         buildkite-agent
+                         buildkite-agent && \
+    mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
 
-# Install the magic wrapper.
+# Install the magic wrapper
 ADD https://raw.githubusercontent.com/docker/docker/v1.8.2/hack/dind /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
 
@@ -26,11 +28,9 @@ RUN chmod +x /usr/local/bin/wrapdocker
 RUN curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-RUN mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
-
 ENV BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks \
-    BUILDKITE_HOOKS_PATH=/buildkite/plugins
+    BUILDKITE_PLUGINS_PATH=/buildkite/plugins
 
 # Internal docker runs out of a volume
 VOLUME /var/lib/docker

--- a/dind/experimental/1.8.2/Dockerfile
+++ b/dind/experimental/1.8.2/Dockerfile
@@ -10,14 +10,17 @@ RUN apt-get update -qq && apt-get install -qqy \
     openssh-client \
     git
 
-# Install Docker & Buildkite
+# Install Docker
 RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
     echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
+    apt-get update -qq && \
+    apt-get install -qqy docker-engine=1.8.2-0~trusty
+
+# Install Buildkite
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
     echo 'deb https://apt.buildkite.com/buildkite-agent experimental main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
-    apt-get install -qqy docker-engine=1.8.2-0~trusty \
-                         buildkite-agent && \
+    apt-get install -qqy buildkite-agent && \
     mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
 
 # Install the magic wrapper

--- a/dind/experimental/1.8.2/test.sh
+++ b/dind/experimental/1.8.2/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+tag="buildkite-agent-test:dind-experimental-1.8.2"
+
+docker build --tag "$tag" .
+docker run -it --rm=true --privileged=true "$tag" --version
+
+echo -e "\033[33;32mLooks good!\033[0m"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Builds and tests all the Dockerfiles in this repo to ensure that everything builds AOK
+
+set -eu
+
+# Returns a list like so:
+# ./Dockerfile
+# ./beta/Dockerfile
+# ./dind/1.6.2/Dockerfile
+docker_files=$(find . -name Dockerfile -type f)
+
+for docker_file in $docker_files; do
+  # We want:
+  # ./Dockerfile            -> buildkite-agent:test
+  # ./beta/Dockerfile       -> buildkite-agent:test-beta
+  # ./dind/1.6.2/Dockerfile -> buildkite-agent:test-dind-1.6.2
+
+  # Strip off tailing /Dockerfile
+  tag="${docker_file//\/Dockerfile}"
+  # Strip off leading ./
+  tag="${tag//.\/}"
+  # Replace all / with -
+  tag="${tag//\//-}"
+
+  tag="buildkite-agent-test:$tag"
+
+  # Change into the directory
+  pushd $(dirname "$docker_file") > /dev/null
+
+  echo -e "\033[33;36m--- Building $docker_file as $tag\033[0m"
+  docker build --tag "$tag" .
+
+  echo -e "\033[33;36m--- Testing $tag\033[0m"
+  docker run -it --rm=true --privileged=true "$tag" --version
+
+  echo -e "\033[33;32mLooks good! \\m/\\m/\033[0m"
+
+  popd > /dev/null
+done
+
+echo -e "\033[33;32mAll images looks good!\033[0m"

--- a/test.sh
+++ b/test.sh
@@ -32,6 +32,7 @@ for docker_file in $docker_files; do
   docker build --tag "$tag" .
 
   echo -e "\033[33;36m--- Testing $tag\033[0m"
+  echo "docker run -it --rm=true --privileged=true \"$tag\" --version"
   docker run -it --rm=true --privileged=true "$tag" --version
 
   echo -e "\033[33;32mLooks good! \\m/\\m/\033[0m"

--- a/test_all.sh
+++ b/test_all.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Builds and tests all the images
+
+set -eu
+
+for test_file in $(find . -name test.sh -type f); do
+  # Change into the directory
+  pushd $(dirname "$test_file") > /dev/null
+
+  ./test.sh
+
+  popd > /dev/null
+done
+
+echo -e "\033[33;32mAll images looks good!\033[0m"

--- a/test_all.sh
+++ b/test_all.sh
@@ -5,7 +5,6 @@
 set -eu
 
 for test_file in $(find . -name test.sh -type f); do
-  # Change into the directory
   pushd $(dirname "$test_file") > /dev/null
 
   ./test.sh

--- a/ubuntu-beta/Dockerfile
+++ b/ubuntu-beta/Dockerfile
@@ -1,4 +1,0 @@
-FROM buildkite/agent:ubuntu
-MAINTAINER Tim Lucas <tim@buildkite.com>
-
-RUN DESTINATION=/buildkite BETA=true bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -14,10 +14,9 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2
     echo 'deb https://apt.buildkite.com/buildkite-agent stable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
     apt-get install -y buildkite-agent && \
-    mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
-
-# Copy the bootstrap to /buildkite in case that's what people were expecting
-RUN cp /usr/share/buildkite-agent/bootstrap.sh /buildkite/bootstrap.sh
+    mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins && \
+    # Copy the bootstrap to /buildkite in case that's what people were expecting
+    cp /usr/share/buildkite-agent/bootstrap.sh /buildkite/bootstrap.sh
 
 ENV BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
     BUILDKITE_BUILD_PATH=/buildkite/builds \

--- a/ubuntu/beta/Dockerfile
+++ b/ubuntu/beta/Dockerfile
@@ -10,8 +10,12 @@ RUN apt-get update -qq && apt-get install -qqy \
     git
 
 # Install Buildkite
+#
+# The buildkite-agent apt source points to 'stable' instead of 'unstable'
+# because unstable is currently broken, and there's no other unstable releases
+# since v2.1.4
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
-    echo 'deb https://apt.buildkite.com/buildkite-agent unstable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
+    echo 'deb https://apt.buildkite.com/buildkite-agent stable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
     apt-get install -y buildkite-agent && \
     mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins

--- a/ubuntu/beta/Dockerfile
+++ b/ubuntu/beta/Dockerfile
@@ -13,11 +13,10 @@ RUN apt-get update -qq && apt-get install -qqy \
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
     echo 'deb https://apt.buildkite.com/buildkite-agent unstable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
-    apt-get install -y buildkite-agent && \
-    mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
-
-# Copy the bootstrap to /buildkite in case that's what people were expecting
-RUN cp /usr/share/buildkite-agent/bootstrap.sh /buildkite/bootstrap.sh
+    apt-get install -qqy buildkite-agent && \
+    mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins && \
+    # Copy the bootstrap to /buildkite in case that's what people were expecting
+    cp /usr/share/buildkite-agent/bootstrap.sh /buildkite/bootstrap.sh
 
 ENV BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
     BUILDKITE_BUILD_PATH=/buildkite/builds \

--- a/ubuntu/beta/Dockerfile
+++ b/ubuntu/beta/Dockerfile
@@ -10,12 +10,8 @@ RUN apt-get update -qq && apt-get install -qqy \
     git
 
 # Install Buildkite
-#
-# The buildkite-agent apt source points to 'stable' instead of 'unstable'
-# because unstable is currently broken, and there's no other unstable releases
-# since v2.1.4
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
-    echo 'deb https://apt.buildkite.com/buildkite-agent stable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
+    echo 'deb https://apt.buildkite.com/buildkite-agent unstable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
     apt-get install -y buildkite-agent && \
     mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins

--- a/ubuntu/beta/Dockerfile
+++ b/ubuntu/beta/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -qq && apt-get install -qqy \
 
 # Install Buildkite
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
-    echo 'deb https://apt.buildkite.com/buildkite-agent stable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
+    echo 'deb https://apt.buildkite.com/buildkite-agent unstable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
     apt-get install -y buildkite-agent && \
     mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins

--- a/ubuntu/beta/test.sh
+++ b/ubuntu/beta/test.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-tag="buildkite-agent-test:latest"
+tag="buildkite-agent-test:ubuntu-beta"
 
 docker build --tag "$tag" .
 docker run -it --rm=true "$tag" --version

--- a/ubuntu/experimental/Dockerfile
+++ b/ubuntu/experimental/Dockerfile
@@ -11,16 +11,12 @@ RUN apt-get update -qq && apt-get install -qqy \
 
 # Install Buildkite
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
-    echo 'deb https://apt.buildkite.com/buildkite-agent stable main' > /etc/apt/sources.list.d/buildkite-agent.list && \
+    echo 'deb https://apt.buildkite.com/buildkite-agent experimental main' > /etc/apt/sources.list.d/buildkite-agent.list && \
     apt-get update -qq && \
-    apt-get install -y buildkite-agent && \
+    apt-get install -qqy buildkite-agent && \
     mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
 
-# Copy the bootstrap to /buildkite in case that's what people were expecting
-RUN cp /usr/share/buildkite-agent/bootstrap.sh /buildkite/bootstrap.sh
-
-ENV BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
-    BUILDKITE_BUILD_PATH=/buildkite/builds \
+ENV BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks \
     BUILDKITE_PLUGINS_PATH=/buildkite/plugins
 

--- a/ubuntu/experimental/test.sh
+++ b/ubuntu/experimental/test.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-tag="buildkite-agent-test:latest"
+tag="buildkite-agent-test:ubuntu-experimental"
 
 docker build --tag "$tag" .
 docker run -it --rm=true "$tag" --version


### PR DESCRIPTION
@lox @lachie this changes the Ubuntu packages to just use the standard Buildkite installer, but changes the paths to be `/buildkite`. I've copied the `bootstrap.sh` to the right path in case someone was depending on it.

Also in version 2.2 of the buildkite-agent there'll be no bootstrap.sh, it'll be completely self-contained

I'm a heads up @lachie, I'm changing the `ubuntu-beta` beta tag name to `beta-ubuntu`… but I'll leave the old one there.

It also adds an image for experimental (master) builds of the agent… because I want to test some stuff :)
