### PR TITLE
Update dind images to use docker dind wrapper

### DIFF
--- a/dind/1.6.2/Dockerfile
+++ b/dind/1.6.2/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-# Let's start with some basic stuff.
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
@@ -8,23 +8,26 @@ RUN apt-get update -qq && apt-get install -qqy \
     lxc \
     iptables \
     openssh-client \
-    git
+    git \
+    --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-# Install Docker
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9 && \
-    echo 'deb https://get.docker.com/ubuntu docker main' > /etc/apt/sources.list.d/docker.list && \
-    apt-get update -q && \
-    apt-get install -q -y lxc-docker-1.6.2
+ENV DIND_COMMIT=723d43387a5c04ef8588c7e1557aa163e268581c \
+    DOCKER_BUCKET=get.docker.com \
+    DOCKER_VERSION=1.6.2 \
+    DOCKER_COMPOSE_VERSION=1.3.1
 
-# Install the magic wrapper.
-ADD https://raw.githubusercontent.com/jpetazzo/dind/master/wrapdocker /usr/local/bin/wrapdocker
-RUN chmod +x /usr/local/bin/wrapdocker
+RUN curl -fL "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -o /usr/local/sbin/dind \
+    && chmod +x /usr/local/sbin/dind
 
-# Install Docker Compose
-RUN curl -L https://github.com/docker/compose/releases/download/1.3.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
+RUN curl -fL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}" -o /usr/local/bin/docker \
+    && chmod +x /usr/local/bin/docker
+
+RUN curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-# Install Buildkite
+VOLUME /var/lib/docker
+EXPOSE 2375
+
 RUN DESTINATION=/buildkite bash -c \
     "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
 
@@ -33,8 +36,7 @@ ENV PATH=$PATH:/buildkite/bin \
     BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks
 
-# Internal docker runs out of a volume
-VOLUME /var/lib/docker
+ADD docker-entrypoint.sh /usr/local/sbin/docker-entrypoint.sh
 
-ENTRYPOINT ["wrapdocker","buildkite-agent"]
+ENTRYPOINT ["dind","docker-entrypoint.sh", "buildkite-agent"]
 CMD ["start"]

--- a/dind/1.6.2/docker-entrypoint.sh
+++ b/dind/1.6.2/docker-entrypoint.sh
@@ -1,27 +1,17 @@
 #!/bin/bash -e
 
-# If we were given a PORT environment variable, start as a simple daemon;
-# otherwise, spawn a shell as well
-if [ "$PORT" ]
-then
-  exec docker -d -H 0.0.0.0:$PORT -H unix:///var/run/docker.sock \
-    $DOCKER_DAEMON_ARGS
-else
-  if [ "$LOG" == "file" ]
-  then
-    docker -d $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
-  else
-    docker -d $DOCKER_DAEMON_ARGS &
+: ${DOCKER_DAEMON_ARG="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+
+docker -d $DOCKER_DAEMON_ARGS &
+
+(( timeout = 60 + SECONDS ))
+until docker info >/dev/null 2>&1
+do
+  if (( SECONDS >= timeout )); then
+    echo 'Timed out trying to connect to internal docker host.' >&2
+    exit 1
   fi
-  (( timeout = 60 + SECONDS ))
-  until docker info >/dev/null 2>&1
-  do
-    if (( SECONDS >= timeout )); then
-      echo 'Timed out trying to connect to internal docker host.' >&2
-      break
-    fi
-    sleep 1
-  done
-  [[ $1 ]] && exec "$@"
-  exec bash --login
-fi
+  sleep 1
+done
+
+[[ $1 ]] && exec "$@"

--- a/dind/1.6.2/docker-entrypoint.sh
+++ b/dind/1.6.2/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+# If we were given a PORT environment variable, start as a simple daemon;
+# otherwise, spawn a shell as well
+if [ "$PORT" ]
+then
+  exec docker -d -H 0.0.0.0:$PORT -H unix:///var/run/docker.sock \
+    $DOCKER_DAEMON_ARGS
+else
+  if [ "$LOG" == "file" ]
+  then
+    docker -d $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
+  else
+    docker -d $DOCKER_DAEMON_ARGS &
+  fi
+  (( timeout = 60 + SECONDS ))
+  until docker info >/dev/null 2>&1
+  do
+    if (( SECONDS >= timeout )); then
+      echo 'Timed out trying to connect to internal docker host.' >&2
+      break
+    fi
+    sleep 1
+  done
+  [[ $1 ]] && exec "$@"
+  exec bash --login
+fi

--- a/dind/1.7.0/Dockerfile
+++ b/dind/1.7.0/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -qq && apt-get install -qqy \
 ENV DIND_COMMIT=4e899d64e020a67ca05f913d354aa8d99a341a7b \
     DOCKER_BUCKET=get.docker.com \
     DOCKER_VERSION=1.7.0 \
-    DOCKER_COMPOSE_VERSION=1.3.1
+    DOCKER_COMPOSE_VERSION=1.4.2
 
 RUN curl -fL "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -o /usr/local/sbin/dind \
     && chmod +x /usr/local/sbin/dind

--- a/dind/1.7.0/Dockerfile
+++ b/dind/1.7.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-# Let's start with some basic stuff.
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
@@ -8,23 +8,26 @@ RUN apt-get update -qq && apt-get install -qqy \
     lxc \
     iptables \
     openssh-client \
-    git
+    git \
+    --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-# Install Docker
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9 && \
-    echo 'deb https://get.docker.com/ubuntu docker main' > /etc/apt/sources.list.d/docker.list && \
-    apt-get update -q && \
-    apt-get install -q -y lxc-docker-1.7.0
+ENV DIND_COMMIT=4e899d64e020a67ca05f913d354aa8d99a341a7b \
+    DOCKER_BUCKET=get.docker.com \
+    DOCKER_VERSION=1.7.0 \
+    DOCKER_COMPOSE_VERSION=1.3.1
 
-# Install the magic wrapper.
-ADD https://raw.githubusercontent.com/jpetazzo/dind/master/wrapdocker /usr/local/bin/wrapdocker
-RUN chmod +x /usr/local/bin/wrapdocker
+RUN curl -fL "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -o /usr/local/sbin/dind \
+    && chmod +x /usr/local/sbin/dind
 
-# Install Docker Compose
-RUN curl -L https://github.com/docker/compose/releases/download/1.3.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
+RUN curl -fL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}" -o /usr/local/bin/docker \
+    && chmod +x /usr/local/bin/docker
+
+RUN curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-# Install Buildkite
+VOLUME /var/lib/docker
+EXPOSE 2375
+
 RUN DESTINATION=/buildkite bash -c \
     "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
 
@@ -33,8 +36,7 @@ ENV PATH=$PATH:/buildkite/bin \
     BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks
 
-# Internal docker runs out of a volume
-VOLUME /var/lib/docker
+ADD docker-entrypoint.sh /usr/local/sbin/docker-entrypoint.sh
 
-ENTRYPOINT ["wrapdocker","buildkite-agent"]
+ENTRYPOINT ["dind","docker-entrypoint.sh", "buildkite-agent"]
 CMD ["start"]

--- a/dind/1.7.0/docker-entrypoint.sh
+++ b/dind/1.7.0/docker-entrypoint.sh
@@ -1,27 +1,17 @@
 #!/bin/bash -e
 
-# If we were given a PORT environment variable, start as a simple daemon;
-# otherwise, spawn a shell as well
-if [ "$PORT" ]
-then
-  exec docker -d -H 0.0.0.0:$PORT -H unix:///var/run/docker.sock \
-    $DOCKER_DAEMON_ARGS
-else
-  if [ "$LOG" == "file" ]
-  then
-    docker -d $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
-  else
-    docker -d $DOCKER_DAEMON_ARGS &
+: ${DOCKER_DAEMON_ARG="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+
+docker -d $DOCKER_DAEMON_ARGS &
+
+(( timeout = 60 + SECONDS ))
+until docker info >/dev/null 2>&1
+do
+  if (( SECONDS >= timeout )); then
+    echo 'Timed out trying to connect to internal docker host.' >&2
+    exit 1
   fi
-  (( timeout = 60 + SECONDS ))
-  until docker info >/dev/null 2>&1
-  do
-    if (( SECONDS >= timeout )); then
-      echo 'Timed out trying to connect to internal docker host.' >&2
-      break
-    fi
-    sleep 1
-  done
-  [[ $1 ]] && exec "$@"
-  exec bash --login
-fi
+  sleep 1
+done
+
+[[ $1 ]] && exec "$@"

--- a/dind/1.7.0/docker-entrypoint.sh
+++ b/dind/1.7.0/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+# If we were given a PORT environment variable, start as a simple daemon;
+# otherwise, spawn a shell as well
+if [ "$PORT" ]
+then
+  exec docker -d -H 0.0.0.0:$PORT -H unix:///var/run/docker.sock \
+    $DOCKER_DAEMON_ARGS
+else
+  if [ "$LOG" == "file" ]
+  then
+    docker -d $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
+  else
+    docker -d $DOCKER_DAEMON_ARGS &
+  fi
+  (( timeout = 60 + SECONDS ))
+  until docker info >/dev/null 2>&1
+  do
+    if (( SECONDS >= timeout )); then
+      echo 'Timed out trying to connect to internal docker host.' >&2
+      break
+    fi
+    sleep 1
+  done
+  [[ $1 ]] && exec "$@"
+  exec bash --login
+fi

--- a/dind/1.7.1/Dockerfile
+++ b/dind/1.7.1/Dockerfile
@@ -1,29 +1,33 @@
 FROM ubuntu:14.04
 
-# Let's start with some basic stuff.
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
     curl \
+    lxc \
     iptables \
     openssh-client \
-    git
+    git \
+    --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-# Install Docker
-RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
-    echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
-    apt-get update -q && \
-    apt-get install -q -y docker-engine=1.7.1-0~trusty
+ENV DIND_COMMIT=4e899d64e020a67ca05f913d354aa8d99a341a7b \
+    DOCKER_BUCKET=get.docker.com \
+    DOCKER_VERSION=1.7.1 \
+    DOCKER_COMPOSE_VERSION=1.3.1
 
-# Install the magic wrapper.
-ADD https://raw.githubusercontent.com/docker/docker/v1.7.1/hack/dind /usr/local/bin/wrapdocker
-RUN chmod +x /usr/local/bin/wrapdocker
+RUN curl -fL "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -o /usr/local/sbin/dind \
+    && chmod +x /usr/local/sbin/dind
 
-# Install Docker Compose
-RUN curl -L https://github.com/docker/compose/releases/download/1.4.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
+RUN curl -fL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}" -o /usr/local/bin/docker \
+    && chmod +x /usr/local/bin/docker
+
+RUN curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-# Install Buildkite
+VOLUME /var/lib/docker
+EXPOSE 2375
+
 RUN DESTINATION=/buildkite bash -c \
     "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
 
@@ -32,8 +36,7 @@ ENV PATH=$PATH:/buildkite/bin \
     BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks
 
-# Internal docker runs out of a volume
-VOLUME /var/lib/docker
+ADD docker-entrypoint.sh /usr/local/sbin/docker-entrypoint.sh
 
-ENTRYPOINT ["wrapdocker","buildkite-agent"]
+ENTRYPOINT ["dind","docker-entrypoint.sh", "buildkite-agent"]
 CMD ["start"]

--- a/dind/1.7.1/Dockerfile
+++ b/dind/1.7.1/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -qq && apt-get install -qqy \
 ENV DIND_COMMIT=4e899d64e020a67ca05f913d354aa8d99a341a7b \
     DOCKER_BUCKET=get.docker.com \
     DOCKER_VERSION=1.7.1 \
-    DOCKER_COMPOSE_VERSION=1.3.1
+    DOCKER_COMPOSE_VERSION=1.4.2
 
 RUN curl -fL "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -o /usr/local/sbin/dind \
     && chmod +x /usr/local/sbin/dind

--- a/dind/1.7.1/docker-entrypoint.sh
+++ b/dind/1.7.1/docker-entrypoint.sh
@@ -1,27 +1,17 @@
 #!/bin/bash -e
 
-# If we were given a PORT environment variable, start as a simple daemon;
-# otherwise, spawn a shell as well
-if [ "$PORT" ]
-then
-  exec docker -d -H 0.0.0.0:$PORT -H unix:///var/run/docker.sock \
-    $DOCKER_DAEMON_ARGS
-else
-  if [ "$LOG" == "file" ]
-  then
-    docker -d $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
-  else
-    docker -d $DOCKER_DAEMON_ARGS &
+: ${DOCKER_DAEMON_ARG="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+
+docker -d $DOCKER_DAEMON_ARGS &
+
+(( timeout = 60 + SECONDS ))
+until docker info >/dev/null 2>&1
+do
+  if (( SECONDS >= timeout )); then
+    echo 'Timed out trying to connect to internal docker host.' >&2
+    exit 1
   fi
-  (( timeout = 60 + SECONDS ))
-  until docker info >/dev/null 2>&1
-  do
-    if (( SECONDS >= timeout )); then
-      echo 'Timed out trying to connect to internal docker host.' >&2
-      break
-    fi
-    sleep 1
-  done
-  [[ $1 ]] && exec "$@"
-  exec bash --login
-fi
+  sleep 1
+done
+
+[[ $1 ]] && exec "$@"

--- a/dind/1.7.1/docker-entrypoint.sh
+++ b/dind/1.7.1/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+# If we were given a PORT environment variable, start as a simple daemon;
+# otherwise, spawn a shell as well
+if [ "$PORT" ]
+then
+  exec docker -d -H 0.0.0.0:$PORT -H unix:///var/run/docker.sock \
+    $DOCKER_DAEMON_ARGS
+else
+  if [ "$LOG" == "file" ]
+  then
+    docker -d $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
+  else
+    docker -d $DOCKER_DAEMON_ARGS &
+  fi
+  (( timeout = 60 + SECONDS ))
+  until docker info >/dev/null 2>&1
+  do
+    if (( SECONDS >= timeout )); then
+      echo 'Timed out trying to connect to internal docker host.' >&2
+      break
+    fi
+    sleep 1
+  done
+  [[ $1 ]] && exec "$@"
+  exec bash --login
+fi

--- a/dind/1.8.2/Dockerfile
+++ b/dind/1.8.2/Dockerfile
@@ -1,29 +1,33 @@
 FROM ubuntu:14.04
 
-# Let's start with some basic stuff.
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
     curl \
+    lxc \
     iptables \
     openssh-client \
-    git
+    git \
+    --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-# Install Docker
-RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
-    echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
-    apt-get update -q && \
-    apt-get install -q -y docker-engine=1.8.2-0~trusty
+ENV DIND_COMMIT=4e899d64e020a67ca05f913d354aa8d99a341a7b \
+    DOCKER_BUCKET=get.docker.com \
+    DOCKER_VERSION=1.8.2 \
+    DOCKER_COMPOSE_VERSION=1.4.2
 
-# Install the magic wrapper.
-ADD https://raw.githubusercontent.com/docker/docker/v1.8.2/hack/dind /usr/local/bin/wrapdocker
-RUN chmod +x /usr/local/bin/wrapdocker
+RUN curl -fL "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -o /usr/local/sbin/dind \
+    && chmod +x /usr/local/sbin/dind
 
-# Install Docker Compose
-RUN curl -L https://github.com/docker/compose/releases/download/1.4.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
+RUN curl -fL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}" -o /usr/local/bin/docker \
+    && chmod +x /usr/local/bin/docker
+
+RUN curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-# Install Buildkite
+VOLUME /var/lib/docker
+EXPOSE 2375
+
 RUN DESTINATION=/buildkite bash -c \
     "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
 
@@ -32,8 +36,7 @@ ENV PATH=$PATH:/buildkite/bin \
     BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks
 
-# Internal docker runs out of a volume
-VOLUME /var/lib/docker
+ADD docker-entrypoint.sh /usr/local/sbin/docker-entrypoint.sh
 
-ENTRYPOINT ["wrapdocker","buildkite-agent"]
+ENTRYPOINT ["dind","docker-entrypoint.sh", "buildkite-agent"]
 CMD ["start"]

--- a/dind/1.8.2/docker-entrypoint.sh
+++ b/dind/1.8.2/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+: ${DOCKER_DAEMON_ARG="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+
+docker daemon $DOCKER_DAEMON_ARGS &
+
+(( timeout = 60 + SECONDS ))
+until docker info >/dev/null 2>&1
+do
+  if (( SECONDS >= timeout )); then
+    echo 'Timed out trying to connect to internal docker host.' >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+[[ $1 ]] && exec "$@"

--- a/dind/1.8.3/Dockerfile
+++ b/dind/1.8.3/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:14.04
+
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
+RUN apt-get update -qq && apt-get install -qqy \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    lxc \
+    iptables \
+    openssh-client \
+    git \
+    --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV DIND_COMMIT=4e899d64e020a67ca05f913d354aa8d99a341a7b \
+    DOCKER_BUCKET=get.docker.com \
+    DOCKER_VERSION=1.8.3 \
+    DOCKER_COMPOSE_VERSION=1.4.2
+
+RUN curl -fL "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -o /usr/local/sbin/dind \
+    && chmod +x /usr/local/sbin/dind
+
+RUN curl -fL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}" -o /usr/local/bin/docker \
+    && chmod +x /usr/local/bin/docker
+
+RUN curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/docker-compose
+
+VOLUME /var/lib/docker
+EXPOSE 2375
+
+RUN DESTINATION=/buildkite bash -c \
+    "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
+
+ENV PATH=$PATH:/buildkite/bin \
+    BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
+    BUILDKITE_BUILD_PATH=/buildkite/builds \
+    BUILDKITE_HOOKS_PATH=/buildkite/hooks
+
+ADD docker-entrypoint.sh /usr/local/sbin/docker-entrypoint.sh
+
+ENTRYPOINT ["dind","docker-entrypoint.sh", "buildkite-agent"]
+CMD ["start"]

--- a/dind/1.8.3/docker-entrypoint.sh
+++ b/dind/1.8.3/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+: ${DOCKER_DAEMON_ARG="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+
+docker daemon $DOCKER_DAEMON_ARGS &
+
+(( timeout = 60 + SECONDS ))
+until docker info >/dev/null 2>&1
+do
+  if (( SECONDS >= timeout )); then
+    echo 'Timed out trying to connect to internal docker host.' >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+[[ $1 ]] && exec "$@"


### PR DESCRIPTION
This uses a similar approach to the official Docker DIND images: https://github.com/docker-library/docker/blob/master/1.8/dind/Dockerfile

This also fixes a current issue where the more recent dind images don't actually launch the docker daemon.
