### PR TITLE
Add experimental dind builds, tests and Alpine fixes

### DIFF
--- a/.buildkite/pipeline
+++ b/.buildkite/pipeline
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec ./scripts/buildkite_pipeline.sh

--- a/beta/Dockerfile
+++ b/beta/Dockerfile
@@ -1,4 +1,5 @@
 FROM buildkite/agent
 MAINTAINER Tim Lucas <tim@buildkite.com>
+# BK-TAG: beta
 
 RUN DESTINATION=/buildkite BETA=true bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"

--- a/dind/1.6.2/Dockerfile
+++ b/dind/1.6.2/Dockerfile
@@ -1,4 +1,6 @@
 FROM ubuntu:14.04
+# BK-TAG: dind-1.6.2
+# BK-PRIVILEGED
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN apt-get update -qq && apt-get install -qqy \

--- a/dind/1.7.0/Dockerfile
+++ b/dind/1.7.0/Dockerfile
@@ -1,4 +1,6 @@
 FROM ubuntu:14.04
+# BK-TAG: dind-1.7.0
+# BK-PRIVILEGED
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN apt-get update -qq && apt-get install -qqy \

--- a/dind/1.7.1/Dockerfile
+++ b/dind/1.7.1/Dockerfile
@@ -1,4 +1,6 @@
 FROM ubuntu:14.04
+# BK-TAG: dind-1.7.1
+# BK-PRIVILEGED
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN apt-get update -qq && apt-get install -qqy \

--- a/dind/1.8.2/Dockerfile
+++ b/dind/1.8.2/Dockerfile
@@ -1,4 +1,6 @@
 FROM ubuntu:14.04
+# BK-TAG: dind-1.8.2
+# BK-PRIVILEGED
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN apt-get update -qq && apt-get install -qqy \

--- a/dind/1.8.3/Dockerfile
+++ b/dind/1.8.3/Dockerfile
@@ -1,4 +1,6 @@
 FROM ubuntu:14.04
+# BK-TAG: dind-1.8.3
+# BK-PRIVILEGED
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN apt-get update -qq && apt-get install -qqy \

--- a/dind/beta/1.7.1/Dockerfile
+++ b/dind/beta/1.7.1/Dockerfile
@@ -1,39 +1,44 @@
 FROM ubuntu:14.04
+# BK-TAG: beta-dind-1.7.1
+# BK-PRIVILEGED
 
-# Let's start with some basic stuff.
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
-    iptables \
     curl \
+    lxc \
+    iptables \
     openssh-client \
-    git
+    git \
+    --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-# Install Docker & Buildkite
-RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
-    echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
-    echo 'deb https://apt.buildkite.com/buildkite-agent beta main' > /etc/apt/sources.list.d/buildkite-agent.list && \
-    apt-get update -qq && \
-    apt-get install -qqy docker-engine=1.7.1-0~trusty \
-                         buildkite-agent
+ENV DIND_COMMIT=4e899d64e020a67ca05f913d354aa8d99a341a7b \
+    DOCKER_BUCKET=get.docker.com \
+    DOCKER_VERSION=1.7.1 \
+    DOCKER_COMPOSE_VERSION=1.4.2
 
-# Install the magic wrapper.
-ADD https://raw.githubusercontent.com/docker/docker/v1.7.1/hack/dind /usr/local/bin/wrapdocker
-RUN chmod +x /usr/local/bin/wrapdocker
+RUN curl -fL "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -o /usr/local/sbin/dind \
+    && chmod +x /usr/local/sbin/dind
 
-# Install Docker Compose
-RUN curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
+RUN curl -fL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}" -o /usr/local/bin/docker \
+    && chmod +x /usr/local/bin/docker
+
+RUN curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-RUN mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
-
-ENV BUILDKITE_BUILD_PATH=/buildkite/builds \
-    BUILDKITE_HOOKS_PATH=/buildkite/hooks \
-    BUILDKITE_HOOKS_PATH=/buildkite/plugins
-
-# Internal docker runs out of a volume
 VOLUME /var/lib/docker
+EXPOSE 2375
 
-ENTRYPOINT ["wrapdocker","buildkite-agent"]
+RUN DESTINATION=/buildkite BETA=true bash -c \
+    "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
+
+ENV PATH=$PATH:/buildkite/bin \
+    BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
+    BUILDKITE_BUILD_PATH=/buildkite/builds \
+    BUILDKITE_HOOKS_PATH=/buildkite/hooks
+
+ADD docker-entrypoint.sh /usr/local/sbin/docker-entrypoint.sh
+
+ENTRYPOINT ["dind","docker-entrypoint.sh", "buildkite-agent"]
 CMD ["start"]

--- a/dind/beta/1.7.1/docker-entrypoint.sh
+++ b/dind/beta/1.7.1/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+: ${DOCKER_DAEMON_ARG="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+
+docker -d $DOCKER_DAEMON_ARGS &
+
+(( timeout = 60 + SECONDS ))
+until docker info >/dev/null 2>&1
+do
+  if (( SECONDS >= timeout )); then
+    echo 'Timed out trying to connect to internal docker host.' >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+[[ $1 ]] && exec "$@"

--- a/dind/beta/1.8.2/Dockerfile
+++ b/dind/beta/1.8.2/Dockerfile
@@ -1,39 +1,44 @@
 FROM ubuntu:14.04
+# BK-TAG: beta-dind-1.8.2
+# BK-PRIVILEGED
 
-# Let's start with some basic stuff.
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
-    iptables \
     curl \
+    lxc \
+    iptables \
     openssh-client \
-    git
+    git \
+    --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-# Install Docker & Buildkite
-RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
-    echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
-    echo 'deb https://apt.buildkite.com/buildkite-agent beta main' > /etc/apt/sources.list.d/buildkite-agent.list && \
-    apt-get update -qq && \
-    apt-get install -qqy docker-engine=1.8.2-0~trusty \
-                         buildkite-agent
+ENV DIND_COMMIT=4e899d64e020a67ca05f913d354aa8d99a341a7b \
+    DOCKER_BUCKET=get.docker.com \
+    DOCKER_VERSION=1.8.2 \
+    DOCKER_COMPOSE_VERSION=1.4.2
 
-# Install the magic wrapper.
-ADD https://raw.githubusercontent.com/docker/docker/v1.8.2/hack/dind /usr/local/bin/wrapdocker
-RUN chmod +x /usr/local/bin/wrapdocker
+RUN curl -fL "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -o /usr/local/sbin/dind \
+    && chmod +x /usr/local/sbin/dind
 
-# Install Docker Compose
-RUN curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
+RUN curl -fL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}" -o /usr/local/bin/docker \
+    && chmod +x /usr/local/bin/docker
+
+RUN curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
-RUN mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
-
-ENV BUILDKITE_BUILD_PATH=/buildkite/builds \
-    BUILDKITE_HOOKS_PATH=/buildkite/hooks \
-    BUILDKITE_HOOKS_PATH=/buildkite/plugins
-
-# Internal docker runs out of a volume
 VOLUME /var/lib/docker
+EXPOSE 2375
 
-ENTRYPOINT ["wrapdocker","buildkite-agent"]
+RUN DESTINATION=/buildkite BETA=true bash -c \
+    "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"
+
+ENV PATH=$PATH:/buildkite/bin \
+    BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
+    BUILDKITE_BUILD_PATH=/buildkite/builds \
+    BUILDKITE_HOOKS_PATH=/buildkite/hooks
+
+ADD docker-entrypoint.sh /usr/local/sbin/docker-entrypoint.sh
+
+ENTRYPOINT ["dind","docker-entrypoint.sh", "buildkite-agent"]
 CMD ["start"]

--- a/dind/beta/1.8.2/docker-entrypoint.sh
+++ b/dind/beta/1.8.2/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+: ${DOCKER_DAEMON_ARG="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+
+docker daemon $DOCKER_DAEMON_ARGS &
+
+(( timeout = 60 + SECONDS ))
+until docker info >/dev/null 2>&1
+do
+  if (( SECONDS >= timeout )); then
+    echo 'Timed out trying to connect to internal docker host.' >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+[[ $1 ]] && exec "$@"

--- a/dind/experimental/1.7.1/docker-entrypoint.sh
+++ b/dind/experimental/1.7.1/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+: ${DOCKER_DAEMON_ARG="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+
+docker -d $DOCKER_DAEMON_ARGS &
+
+(( timeout = 60 + SECONDS ))
+until docker info >/dev/null 2>&1
+do
+  if (( SECONDS >= timeout )); then
+    echo 'Timed out trying to connect to internal docker host.' >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+[[ $1 ]] && exec "$@"

--- a/dind/experimental/1.8.2/Dockerfile
+++ b/dind/experimental/1.8.2/Dockerfile
@@ -1,39 +1,40 @@
 FROM ubuntu:14.04
+# BK-TAG: experimental-dind-1.8.2
+# BK-PRIVILEGED
 
-# Let's start with some basic stuff.
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
 RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
-    iptables \
     curl \
+    lxc \
+    iptables \
     openssh-client \
-    git
+    git \
+    --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-# Install Docker & Buildkite
-RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
-    echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' > /etc/apt/sources.list.d/docker.list && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \
-    echo 'deb https://apt.buildkite.com/buildkite-agent experimental main' > /etc/apt/sources.list.d/buildkite-agent.list && \
-    apt-get update -qq && \
-    apt-get install -qqy docker-engine=1.8.2-0~trusty \
-                         buildkite-agent
-
-# Install the magic wrapper.
-ADD https://raw.githubusercontent.com/docker/docker/v1.8.2/hack/dind /usr/local/bin/wrapdocker
-RUN chmod +x /usr/local/bin/wrapdocker
-
-# Install Docker Compose
-RUN curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
-    chmod +x /usr/local/bin/docker-compose
-
-RUN mkdir -p /buildkite/hooks /buildkite/builds /buildkite/plugins
-
-ENV BUILDKITE_BUILD_PATH=/buildkite/builds \
+ENV DIND_COMMIT=4e899d64e020a67ca05f913d354aa8d99a341a7b \
+    DOCKER_BUCKET=get.docker.com \
+    DOCKER_VERSION=1.8.2 \
+    DOCKER_COMPOSE_VERSION=1.4.2 \
+    BUILDKITE_AGENT_VERSION=master \
+    BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks \
-    BUILDKITE_HOOKS_PATH=/buildkite/plugins
+    BUILDKITE_PLUGINS_PATH=/buildkite/plugins
 
-# Internal docker runs out of a volume
+RUN curl -fL "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -o /usr/local/sbin/dind \
+    && chmod +x /usr/local/sbin/dind \
+    && curl -fL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}" -o /usr/local/bin/docker \
+    && chmod +x /usr/local/bin/docker \
+    && curl -fL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/docker-compose \
+    && curl -fL "https://download.buildkite.com/builds/$(uname -s)/$(uname -m)/buildkite-agent-${BUILDKITE_AGENT_VERSION}" -o /usr/local/bin/buildkite-agent \
+    && chmod +x /usr/local/bin/buildkite-agent
+
+ADD docker-entrypoint.sh /usr/local/sbin/docker-entrypoint.sh
+
 VOLUME /var/lib/docker
+EXPOSE 2375
 
-ENTRYPOINT ["wrapdocker","buildkite-agent"]
+ENTRYPOINT ["dind","docker-entrypoint.sh", "buildkite-agent"]
 CMD ["start"]

--- a/dind/experimental/1.8.2/docker-entrypoint.sh
+++ b/dind/experimental/1.8.2/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+: ${DOCKER_DAEMON_ARG="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+
+docker daemon $DOCKER_DAEMON_ARGS &
+
+(( timeout = 60 + SECONDS ))
+until docker info >/dev/null 2>&1
+do
+  if (( SECONDS >= timeout )); then
+    echo 'Timed out trying to connect to internal docker host.' >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+[[ $1 ]] && exec "$@"

--- a/dind/experimental/1.8.3/Dockerfile
+++ b/dind/experimental/1.8.3/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:14.04
-# BK-TAG: experimental-dind-1.7.1
+# BK-TAG: experimental-dind-1.8.3
 # BK-PRIVILEGED
 
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
@@ -15,9 +15,8 @@ RUN apt-get update -qq && apt-get install -qqy \
 
 ENV DIND_COMMIT=4e899d64e020a67ca05f913d354aa8d99a341a7b \
     DOCKER_BUCKET=get.docker.com \
-    DOCKER_VERSION=1.7.1 \
+    DOCKER_VERSION=1.8.3 \
     DOCKER_COMPOSE_VERSION=1.4.2 \
-    BUILDKITE_AGENT_VERSION=master \
     BUILDKITE_AGENT_VERSION=master \
     BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks \

--- a/dind/experimental/1.8.3/docker-entrypoint.sh
+++ b/dind/experimental/1.8.3/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+: ${DOCKER_DAEMON_ARG="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+
+docker daemon $DOCKER_DAEMON_ARGS &
+
+(( timeout = 60 + SECONDS ))
+until docker info >/dev/null 2>&1
+do
+  if (( SECONDS >= timeout )); then
+    echo 'Timed out trying to connect to internal docker host.' >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+[[ $1 ]] && exec "$@"

--- a/experimental/Dockerfile
+++ b/experimental/Dockerfile
@@ -1,17 +1,17 @@
 FROM gliderlabs/alpine:3.2
 MAINTAINER Tim Lucas <tim@buildkite.com>
-# BK-TAG: latest
+# BK-TAG: experimental
 
 ENV DOCKER_COMPOSE_VERSION=1.4.2 \
     BUILDKITE_AGENT_VERSION=master \
     BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks \
-    BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh \
-    PATH=$PATH:/buildkite/bin
+    BUILDKITE_PLUGINS_PATH=/buildkite/plugins
 
 RUN apk-install curl wget bash git perl openssh-client py-pip py-yaml \
     && pip install -U pip docker-compose==${DOCKER_COMPOSE_VERSION} \
-    && DESTINATION=/buildkite bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`" \
+    && curl -fL "https://download.buildkite.com/builds/Linux/386/buildkite-agent-${BUILDKITE_AGENT_VERSION}" -o /usr/local/bin/buildkite-agent \
+    && chmod +x /usr/local/bin/buildkite-agent \
     && rm -rf \
       # Clean up any temporary files:
       /tmp/* \

--- a/scripts/buildkite_pipeline.sh
+++ b/scripts/buildkite_pipeline.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Generates a pipeline with a step for each image. This allows you to run
+# all the tests in parallel, as opposed to the test_all.sh script which has to
+# run in serial. It also means you get GH statuses and jobs for each image.
+
+set -eu
+
+echo "steps:"
+
+for DOCKER_FILE in $(find . -name Dockerfile -type f); do
+  TAG=$(./scripts/helpers/extract_tag.sh "${DOCKER_FILE}")
+
+  echo "  - command: \"./scripts/test_image.sh '$(dirname "$DOCKER_FILE")'\""
+  echo "    name: \"${TAG}\""
+  echo "    agents:"
+  echo "      docker: true"
+  echo "    env:"
+  echo "      DOCKER_IMAGE: buildkite-agent-$BUILDKITE_JOB_ID"
+done

--- a/scripts/helpers/extract_privileged.sh
+++ b/scripts/helpers/extract_privileged.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Extracts the privileged flag from our special comment at the top of the Dockerfile
+#
+# For example, if a Dockerfile has "BK-PRIViLEGED" then this will echo "true". If not, then this will echo "false"
+#
+# Usage:
+#   $ ./extract_dockerfile_privileged.sh ubuntu/Dockerfile
+#   false
+#   $ ./extract_dockerfile_privileged.sh dind/1.7.1/Dockerfile
+#   true
+
+set -eu
+
+if [ ! -f "$1" ]; then
+  echo "File not found: $1" >&2
+  exit 1
+fi
+
+if grep --quiet '# BK-PRIVILEGED' "$1"; then
+  echo "true"
+else
+  echo "false"
+fi

--- a/scripts/helpers/extract_tag.sh
+++ b/scripts/helpers/extract_tag.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Extracts the tag from our special comment at the top of the Dockerfile
+#
+# For example, if a Dockerfile has "BK-TAG: hello" then this will echo "hello"
+#
+# Usage:
+#   $ ./extract_dockerfile_tag.sh ubuntu/Dockerfile
+#   ubuntu
+
+set -eu
+
+if [ ! -f "$1" ]; then
+  echo "File not found: $1" >&2
+  exit 1
+fi
+
+# Extract the tag from the BK-TAG comment in the Dockerfile
+TAG=$(sed -n -e 's/# BK-TAG: \(.*\)/\1/p' "$1")
+
+if [ -z "${TAG}" ]; then
+  echo "Failed to extract the BK-TAG comment from $1"  >&2
+  exit 1
+fi
+
+echo "${TAG}"

--- a/scripts/test_all_images.sh
+++ b/scripts/test_all_images.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Builds and tests all the images
+
+set -eu
+
+for docker_file in $(find . -name Dockerfile -type f); do
+  ./scripts/test_image.sh "$(dirname "$docker_file")"
+done
+
+echo -e "\033[33;32mAll images look good!\033[0m"

--- a/scripts/test_image.sh
+++ b/scripts/test_image.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Builds and tests the given buildkite-agent image
+#
+# Usage:
+#   test_image.sh ubuntu
+#   test_image.sh dind/1.8.3
+#
+# The docker image name can be customized by setting the DOCKER_IMAGE env var.
+# For example you might want to set DOCKER_IMAGE="$CI_JOB_ID". The default is
+# "buildkite-agent-test".
+
+set -eu
+
+DOCKER_DIR="$1"
+DOCKER_FILE="${DOCKER_DIR}/Dockerfile"
+
+if [ ! -f "${DOCKER_FILE}" ]; then
+  echo "${DOCKER_FILE} not found" >&2
+  exit 1
+fi
+
+[ -z "${DOCKER_IMAGE:-}" ] && DOCKER_IMAGE="buildkite-agent-test"
+[ -z "${NO_CACHE:-}" ] && NO_CACHE="false"
+
+DOCKER_IMAGE_NAME="${DOCKER_IMAGE}:$(./scripts/helpers/extract_tag.sh "${DOCKER_FILE}")"
+
+# Build
+
+echo "--- :package: Building ${DOCKER_IMAGE_NAME}"
+
+docker build --no-cache="${NO_CACHE}" --tag "${DOCKER_IMAGE_NAME}" "${DOCKER_DIR}"
+
+trap "docker rmi -f \"${DOCKER_IMAGE_NAME}\"" EXIT
+
+# Test
+
+echo "--- :hammer: Testing ${DOCKER_IMAGE_NAME}"
+
+PRIVILEGED=$(./scripts/helpers/extract_privileged.sh "${DOCKER_FILE}")
+
+docker run -it --rm=true --privileged="${PRIVILEGED}" "${DOCKER_IMAGE_NAME}" --version
+
+echo -e "\033[33;32mLooks good!\033[0m"

--- a/ubuntu-beta/Dockerfile
+++ b/ubuntu-beta/Dockerfile
@@ -1,4 +1,5 @@
-FROM buildkite/agent:ubuntu
+FROM buildkite/agent
 MAINTAINER Tim Lucas <tim@buildkite.com>
+# BK-TAG: beta-ubuntu
 
 RUN DESTINATION=/buildkite BETA=true bash -c "`curl -sL https://raw.githubusercontent.com/buildkite/agent/master/install.sh`"

--- a/ubuntu-experimental/Dockerfile
+++ b/ubuntu-experimental/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:14.04
+MAINTAINER Tim Lucas <tim@buildkite.com>
+# BK-TAG: experimental-ubuntu
+
+ENV DOCKER_COMPOSE_VERSION=1.4.2 \
+    BUILDKITE_AGENT_VERSION=master \
+    BUILDKITE_BUILD_PATH=/buildkite/builds \
+    BUILDKITE_HOOKS_PATH=/buildkite/hooks \
+    BUILDKITE_PLUGINS_PATH=/buildkite/plugins
+
+RUN apt-get install -y curl openssh-client git \
+    && curl -fL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/docker-compose \
+    && curl -fL "https://download.buildkite.com/builds/$(uname -s)/$(uname -m)/buildkite-agent-${BUILDKITE_AGENT_VERSION}" -o /usr/local/bin/buildkite-agent \
+    && chmod +x /usr/local/bin/buildkite-agent
+
+ENTRYPOINT ["buildkite-agent"]
+CMD ["start"]

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,5 +1,6 @@
-FROM ubuntu:trusty
+FROM ubuntu:14.04
 MAINTAINER Tim Lucas <tim@buildkite.com>
+# BK-TAG: ubuntu
 
 RUN apt-get install -y curl openssh-client git && \
     curl -L https://github.com/docker/compose/releases/download/1.4.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \


### PR DESCRIPTION
This adds experimental builds for messing with the latest master builds.

It also adds tests for every one of the image, just checking whether the image builds and we can run `buildkite-agent --version`
