### PR TITLE
Dind fixes and tests

### DIFF
--- a/dind/1.6.2/docker-entrypoint.sh
+++ b/dind/1.6.2/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-: ${DOCKER_DAEMON_ARG="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+: ${DOCKER_DAEMON_ARGS="--storage-driver=vfs -H unix:///var/run/docker.sock"}
 
 docker -d $DOCKER_DAEMON_ARGS &
 

--- a/dind/1.7.0/docker-entrypoint.sh
+++ b/dind/1.7.0/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-: ${DOCKER_DAEMON_ARG="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+: ${DOCKER_DAEMON_ARGS="--storage-driver=vfs -H unix:///var/run/docker.sock"}
 
 docker -d $DOCKER_DAEMON_ARGS &
 

--- a/dind/1.7.1/docker-entrypoint.sh
+++ b/dind/1.7.1/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-: ${DOCKER_DAEMON_ARG="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+: ${DOCKER_DAEMON_ARGS="--storage-driver=vfs -H unix:///var/run/docker.sock"}
 
 docker -d $DOCKER_DAEMON_ARGS &
 

--- a/dind/1.8.2/docker-entrypoint.sh
+++ b/dind/1.8.2/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-: ${DOCKER_DAEMON_ARG="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+: ${DOCKER_DAEMON_ARGS="--storage-driver=vfs -H unix:///var/run/docker.sock"}
 
 docker daemon $DOCKER_DAEMON_ARGS &
 

--- a/dind/1.8.3/docker-entrypoint.sh
+++ b/dind/1.8.3/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-: ${DOCKER_DAEMON_ARG="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+: ${DOCKER_DAEMON_ARGS="--storage-driver=vfs -H unix:///var/run/docker.sock"}
 
 docker daemon $DOCKER_DAEMON_ARGS &
 

--- a/scripts/test_image.sh
+++ b/scripts/test_image.sh
@@ -11,6 +11,7 @@
 # "buildkite-agent-test".
 
 set -eu
+set -o pipefail
 
 DOCKER_DIR="$1"
 DOCKER_FILE="${DOCKER_DIR}/Dockerfile"
@@ -40,5 +41,12 @@ echo "--- :hammer: Testing ${DOCKER_IMAGE_NAME}"
 PRIVILEGED=$(./scripts/helpers/extract_privileged.sh "${DOCKER_FILE}")
 
 docker run -it --rm=true --privileged="${PRIVILEGED}" "${DOCKER_IMAGE_NAME}" --version
+
+if [[ "${DOCKER_IMAGE_NAME}" =~ dind ]] ; then
+  echo "--- :hammer: Checking docker-in-docker for ${DOCKER_IMAGE_NAME}"
+  docker run -it --rm=true --privileged \
+    --entrypoint dind  "${DOCKER_IMAGE_NAME}" \
+    docker-entrypoint.sh docker version
+fi
 
 echo -e "\033[33;32mLooks good!\033[0m"


### PR DESCRIPTION
There was a typo in `DOCKER_DAEMON_ARGS` that meant the dind images were using docker defaults, which meant `devicemapper`, which causes issues with udev. This fixes those and adds a test for the dind daemon running.
