### PR TITLE
Whilst reliable, vfs as a docker storage driver is slow. This makes it configurable for dind agents. 

### DIFF
--- a/dind/1.6.2/docker-entrypoint.sh
+++ b/dind/1.6.2/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
-: ${DOCKER_DAEMON_ARGS="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+: ${DOCKER_STORAGE_DRIVER="vfs"}
+: ${DOCKER_DAEMON_ARGS="--storage-driver=$DOCKER_STORAGE_DRIVER -H unix:///var/run/docker.sock"}
 
 docker -d $DOCKER_DAEMON_ARGS &
 

--- a/dind/1.7.0/docker-entrypoint.sh
+++ b/dind/1.7.0/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
-: ${DOCKER_DAEMON_ARGS="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+: ${DOCKER_STORAGE_DRIVER="vfs"}
+: ${DOCKER_DAEMON_ARGS="--storage-driver=$DOCKER_STORAGE_DRIVER -H unix:///var/run/docker.sock"}
 
 docker -d $DOCKER_DAEMON_ARGS &
 

--- a/dind/1.7.1/docker-entrypoint.sh
+++ b/dind/1.7.1/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
-: ${DOCKER_DAEMON_ARGS="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+: ${DOCKER_STORAGE_DRIVER="vfs"}
+: ${DOCKER_DAEMON_ARGS="--storage-driver=$DOCKER_STORAGE_DRIVER -H unix:///var/run/docker.sock"}
 
 docker -d $DOCKER_DAEMON_ARGS &
 

--- a/dind/1.8.2/docker-entrypoint.sh
+++ b/dind/1.8.2/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
-: ${DOCKER_DAEMON_ARGS="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+: ${DOCKER_STORAGE_DRIVER="vfs"}
+: ${DOCKER_DAEMON_ARGS="--storage-driver=$DOCKER_STORAGE_DRIVER -H unix:///var/run/docker.sock"}
 
 docker daemon $DOCKER_DAEMON_ARGS &
 

--- a/dind/1.8.3/docker-entrypoint.sh
+++ b/dind/1.8.3/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
-: ${DOCKER_DAEMON_ARGS="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+: ${DOCKER_STORAGE_DRIVER="vfs"}
+: ${DOCKER_DAEMON_ARGS="--storage-driver=$DOCKER_STORAGE_DRIVER -H unix:///var/run/docker.sock"}
 
 docker daemon $DOCKER_DAEMON_ARGS &
 

--- a/dind/beta/1.7.1/docker-entrypoint.sh
+++ b/dind/beta/1.7.1/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
-: ${DOCKER_DAEMON_ARGS="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+: ${DOCKER_STORAGE_DRIVER="vfs"}
+: ${DOCKER_DAEMON_ARGS="--storage-driver=$DOCKER_STORAGE_DRIVER -H unix:///var/run/docker.sock"}
 
 docker -d $DOCKER_DAEMON_ARGS &
 

--- a/dind/beta/1.8.2/docker-entrypoint.sh
+++ b/dind/beta/1.8.2/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
-: ${DOCKER_DAEMON_ARGS="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+: ${DOCKER_STORAGE_DRIVER="vfs"}
+: ${DOCKER_DAEMON_ARGS="--storage-driver=$DOCKER_STORAGE_DRIVER -H unix:///var/run/docker.sock"}
 
 docker daemon $DOCKER_DAEMON_ARGS &
 

--- a/dind/edge/1.7.1/docker-entrypoint.sh
+++ b/dind/edge/1.7.1/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
-: ${DOCKER_DAEMON_ARGS="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+: ${DOCKER_STORAGE_DRIVER="vfs"}
+: ${DOCKER_DAEMON_ARGS="--storage-driver=$DOCKER_STORAGE_DRIVER -H unix:///var/run/docker.sock"}
 
 docker -d $DOCKER_DAEMON_ARGS &
 

--- a/dind/edge/1.8.2/docker-entrypoint.sh
+++ b/dind/edge/1.8.2/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
-: ${DOCKER_DAEMON_ARGS="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+: ${DOCKER_STORAGE_DRIVER="vfs"}
+: ${DOCKER_DAEMON_ARGS="--storage-driver=$DOCKER_STORAGE_DRIVER -H unix:///var/run/docker.sock"}
 
 docker daemon $DOCKER_DAEMON_ARGS &
 

--- a/dind/edge/1.8.3/docker-entrypoint.sh
+++ b/dind/edge/1.8.3/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
-: ${DOCKER_DAEMON_ARGS="--storage-driver=vfs -H unix:///var/run/docker.sock"}
+: ${DOCKER_STORAGE_DRIVER="vfs"}
+: ${DOCKER_DAEMON_ARGS="--storage-driver=$DOCKER_STORAGE_DRIVER -H unix:///var/run/docker.sock"}
 
 docker daemon $DOCKER_DAEMON_ARGS &
 


### PR DESCRIPTION
This adds a `DOCKER_STORAGE_DRIVER` env for easily using other docker storage drivers in dind images. 
