### PR TITLE
Run the buildkite daemon as a non-root user, buildkite-agent

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -9,7 +9,7 @@ LABEL com.buildkite.distro="alpine" \
     com.buildkite.docker_compose_version=1.5.1
 
 RUN apk add --update --repository http://dl-1.alpinelinux.org/alpine/edge/testing/ tini \
-     && apk-install curl wget bash git perl openssh-client py-pip py-yaml docker\<1.9.2 \
+     && apk-install sudo curl wget bash git perl openssh-client py-pip py-yaml docker\<1.9.2 \
     && pip install -U pip docker-compose==1.5.1 \
     && rm -rf /tmp/* /root/.cache `find / -regex '.*\.py[co]'`
 
@@ -19,7 +19,9 @@ ENV BUILDKITE_AGENT_VERSION=${BUILDKITE_AGENT_VERSION} \
 
 COPY ./scripts/docker/entrypoint.sh ./assets/ssh-env-config.sh /usr/local/bin/
 COPY ./assets/${BUILDKITE_AGENT_VERSION}-386 /buildkite
-RUN ln -s /buildkite/buildkite-agent /usr/local/bin/buildkite-agent
+RUN ln -s /buildkite/buildkite-agent /usr/local/bin/buildkite-agent \
+    && adduser -S buildkite-agent  \
+    && chown -R buildkite-agent: /buildkite
 
 ENTRYPOINT ["/usr/bin/tini", "-vg", "--", "/usr/local/bin/entrypoint.sh", "buildkite-agent"]
 CMD ["start"]

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -18,4 +18,5 @@ if [[ -e /buildkite/bootstrap.sh ]] ; then
   export BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh
 fi
 
-exec /usr/local/bin/ssh-env-config.sh "$@"
+# Run the remainder as the buildkite-agent user
+exec sudo --preserve-env -H -u buildkite-agent /usr/local/bin/ssh-env-config.sh "$@"

--- a/scripts/test_image.sh
+++ b/scripts/test_image.sh
@@ -28,6 +28,14 @@ echo ">> Buildkite version: "
 docker run --rm --entrypoint "buildkite-agent" "${DOCKER_IMAGE_NAME}" --version
 echo -e "\033[33;32mOk\033[0m"
 
+echo ">> Checking entrypoint drops privileges to buildkite-agent: "
+if ! docker run --rm --entrypoint "/usr/local/bin/entrypoint.sh" "${DOCKER_IMAGE_NAME}" whoami | grep "buildkite-agent" ; then
+  echo -e "\033[33;31mAgent isn't running as buildkite-agent\033[0m"
+  exit 1
+else
+  echo -e "\033[33;32mOk\033[0m"
+fi
+
 if [[ -n $(docker_label $DOCKER_IMAGE_NAME "com.buildkite.docker_version") ]] ; then
   echo -e ">> Checking docker client for ${DOCKER_IMAGE_NAME}"
   docker run --rm --entrypoint "docker" "${DOCKER_IMAGE_NAME}" --version
@@ -41,7 +49,7 @@ if [[ -n $(docker_label $DOCKER_IMAGE_NAME "com.buildkite.docker_compose_version
   docker run --rm --entrypoint "docker-compose" "${DOCKER_IMAGE_NAME}" --version
   echo -e "\033[33;32mOk\033[0m"
 else
-  echo -e ">>Skipping docker-compose checks"
+  echo -e ">> Skipping docker-compose checks"
 fi
 
 if [[ $(docker_label $DOCKER_IMAGE_NAME "com.buildkite.docker_dind") == "true" ]] ; then

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -17,7 +17,9 @@ ENV BUILDKITE_AGENT_VERSION=${BUILDKITE_AGENT_VERSION} \
 
 COPY ./scripts/docker/entrypoint.sh ./assets/ssh-env-config.sh /usr/local/bin/
 COPY ./assets/${BUILDKITE_AGENT_VERSION}-386 /buildkite
-RUN ln -s /buildkite/buildkite-agent /usr/local/bin/buildkite-agent
+RUN ln -s /buildkite/buildkite-agent /usr/local/bin/buildkite-agent \
+    && adduser --system buildkite-agent \
+    && chown -R buildkite-agent: /buildkite
 
 ENTRYPOINT ["/usr/local/bin/tini", "-vg", "--", "/usr/local/bin/entrypoint.sh", "buildkite-agent"]
 CMD ["start"]

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -2,7 +2,6 @@ FROM krallin/ubuntu-tini:trusty
 MAINTAINER Tim Lucas <tim@buildkite.com>
 
 ARG BUILDKITE_AGENT_VERSION=stable
-ARG SSH_ENV_COMMIT_REF=bf7e6f0
 
 LABEL com.buildkite.distro="ubuntu" \
     com.buildkite.version=${BUILDKITE_AGENT_VERSION}


### PR DESCRIPTION
Dropping privileges of the buildkite-agent provides some extra level of protection against third-party code being executed by the agent. 
