### PR TITLE
Add ability to bump SSH_ENV and invalidate Docker cache

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,6 +2,7 @@ FROM gliderlabs/alpine:edge
 MAINTAINER Tim Lucas <tim@buildkite.com>
 
 ARG BUILDKITE_AGENT_VERSION=stable
+ARG SSH_ENV_COMMIT_REF=bf7e6f0
 
 LABEL com.buildkite.distro="alpine" \
     com.buildkite.version=${BUILDKITE_AGENT_VERSION} \
@@ -19,7 +20,7 @@ ENV BUILDKITE_AGENT_VERSION=${BUILDKITE_AGENT_VERSION} \
     PATH=$PATH:/buildkite/bin
 
 COPY ./scripts/docker/* /tmp/
-RUN ARCH=386 /tmp/install_buildkite.sh ${BUILDKITE_AGENT_VERSION} \
+RUN ARCH=386 /tmp/install_buildkite.sh ${BUILDKITE_AGENT_VERSION} ${SSH_ENV_COMMIT_REF} \
     && cp /tmp/entrypoint.sh /usr/local/bin/entrypoint.sh \
     && rm -rf /tmp/*
 

--- a/scripts/docker/install_buildkite.sh
+++ b/scripts/docker/install_buildkite.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-: ${SSH_ENV_CONFIG_COMMIT="master"}
+: ${SSH_ENV_CONFIG_COMMIT="$2"}
 : ${OS=$(uname -s)}
 : ${ARCH=$(uname -m)}
 

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -2,6 +2,8 @@ FROM krallin/ubuntu-tini:trusty
 MAINTAINER Tim Lucas <tim@buildkite.com>
 
 ARG BUILDKITE_AGENT_VERSION=stable
+ARG SSH_ENV_COMMIT_REF=bf7e6f0
+
 LABEL com.buildkite.distro="ubuntu" \
     com.buildkite.version=${BUILDKITE_AGENT_VERSION}
 
@@ -15,7 +17,7 @@ ENV BUILDKITE_AGENT_VERSION=${BUILDKITE_AGENT_VERSION} \
     PATH=$PATH:/buildkite/bin
 
 COPY ./scripts/docker/* /tmp/
-RUN /tmp/install_buildkite.sh ${BUILDKITE_AGENT_VERSION} \
+RUN /tmp/install_buildkite.sh ${BUILDKITE_AGENT_VERSION} ${SSH_ENV_COMMIT_REF} \
     && cp /tmp/entrypoint.sh /usr/local/bin/entrypoint.sh \
     && rm -rf /tmp/*
 


### PR DESCRIPTION
To pull in the latest changes from buildkite/docker-ssh-env-config#1 we need to add the SSH env SHA as an arg in the Dockerfile. This hasn't yet been tested.
