### PR TITLE
Add docker tags for alpine images

### DIFF
--- a/scripts/list.sh
+++ b/scripts/list.sh
@@ -24,6 +24,7 @@ BUILDKITE_VERSIONS=(
 )
 
 LATEST_DOCKER=${DOCKER_VERSIONS[${#DOCKER_VERSIONS[@]} - 1]}
+ALPINE_DOCKER=1.9.1
 
 # Returns the major version for a given X.X.X docker version
 docker_major_version() {
@@ -38,11 +39,12 @@ image_name() {
 
 for distro in ${DISTROS[*]} ; do
   for version in ${BUILDKITE_VERSIONS[*]} ; do
-    tags=""
+    tags=()
     if [[ $distro == "alpine" ]] ; then
-      tags="$(sed -e 's/stable/latest/g' <<< $version)"
+      tags+=($(sed -e 's/stable/latest/g' <<< $version))
+      tags+=($(printf "%s-docker-%s" $(image_name "$version" "$distro") $(docker_major_version "$ALPINE_DOCKER")))
     fi
-    printf "%s %s %s %s n/a $tags\n" $(image_name "$version" "$distro") "n/a" "$distro" "$version"
+    printf "%s %s %s %s n/a ${tags[*]-}\n" $(image_name "$version" "$distro") "n/a" "$distro" "$version"
     if [[ ! -f "$distro/Dockerfile.docker-template" ]] ; then
      continue
     fi


### PR DESCRIPTION
Currently there isn't a tag for specific docker versions of alpine images, this adds one such that future humans can refer to past docker versions, via `alpine-docker-1.9`, etc.
