### PR TITLE
Use official alpine images from dockerhub

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -8,8 +8,8 @@ LABEL com.buildkite.distro="alpine" \
     com.buildkite.docker_version=1.9.1 \
     com.buildkite.docker_compose_version=1.5.1
 
-RUN apk add --update --repository http://dl-1.alpinelinux.org/alpine/edge/testing/ tini \
-     && apk-install curl wget bash git perl openssh-client py-pip py-yaml docker\<1.9.2 \
+RUN apk add --update --repository http://dl-1.alpinelinux.org/alpine/edge/community/ tini \
+     && apk add curl wget bash git perl openssh-client py-pip py-yaml docker\<1.9.2 \
     && pip install -U pip docker-compose==1.5.1 \
     && rm -rf /tmp/* /root/.cache `find / -regex '.*\.py[co]'`
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:edge
+FROM alpine:3.3
 MAINTAINER Tim Lucas <tim@buildkite.com>
 
 ARG BUILDKITE_AGENT_VERSION=stable


### PR DESCRIPTION
Given that alpine is now officially supported by docker, this moves to the latest stable release.
