### PR TITLE
Experiment: Rather than have alpine a special case, build with all supported dockers

### DIFF
--- a/alpine/Dockerfile.docker-template
+++ b/alpine/Dockerfile.docker-template
@@ -7,14 +7,13 @@ LABEL com.buildkite.docker_version=${DOCKER_VERSION} \
     com.buildkite.docker_dind=true \
     com.buildkite.docker_compose_version=${DOCKER_COMPOSE_VERSION}
 
+RUN apk add --update --repository http://dl-1.alpinelinux.org/alpine/edge/community/ tini docker=${DOCKER_VERSION} \
+     && apk add curl wget bash git perl openssh-client py-pip py-yaml \
+    && pip install -U pip docker-compose==${DOCKER_COMPOSE_VERSION} \
+    && rm -rf /tmp/* /root/.cache `find / -regex '.*\.py[co]'`
+
 RUN curl -fL "https://raw.githubusercontent.com/docker/docker/v${DOCKER_VERSION}/hack/dind" -o /usr/local/bin/dind \
     && chmod +x /usr/local/bin/dind
-
-RUN curl -fL "https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}" -o /usr/local/bin/docker \
-    && chmod +x /usr/local/bin/docker
-
-RUN curl -fL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose && \
-    chmod +x /usr/local/bin/docker-compose
 
 VOLUME /var/lib/docker
 EXPOSE 2375

--- a/alpine/Dockerfile.docker-template
+++ b/alpine/Dockerfile.docker-template
@@ -1,0 +1,20 @@
+MAINTAINER Tim Lucas <tim@buildkite.com>
+
+ARG DOCKER_VERSION
+ARG DOCKER_COMPOSE_VERSION
+
+LABEL com.buildkite.docker_version=${DOCKER_VERSION} \
+    com.buildkite.docker_dind=true \
+    com.buildkite.docker_compose_version=${DOCKER_COMPOSE_VERSION}
+
+RUN curl -fL "https://raw.githubusercontent.com/docker/docker/v${DOCKER_VERSION}/hack/dind" -o /usr/local/bin/dind \
+    && chmod +x /usr/local/bin/dind
+
+RUN curl -fL "https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}" -o /usr/local/bin/docker \
+    && chmod +x /usr/local/bin/docker
+
+RUN curl -fL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/docker-compose
+
+VOLUME /var/lib/docker
+EXPOSE 2375

--- a/scripts/list.sh
+++ b/scripts/list.sh
@@ -24,7 +24,6 @@ BUILDKITE_VERSIONS=(
 )
 
 LATEST_DOCKER=${DOCKER_VERSIONS[${#DOCKER_VERSIONS[@]} - 1]}
-ALPINE_DOCKER=1.9.1
 
 # Returns the major version for a given X.X.X docker version
 docker_major_version() {
@@ -40,14 +39,8 @@ image_name() {
 for distro in ${DISTROS[*]} ; do
   for version in ${BUILDKITE_VERSIONS[*]} ; do
     tags=()
-    if [[ $distro == "alpine" ]] ; then
-      tags+=($(sed -e 's/stable/latest/g' <<< $version))
-      tags+=($(printf "%s-docker-%s" $(image_name "$version" "$distro") $(docker_major_version "$ALPINE_DOCKER")))
-    fi
+    [[ $distro == "alpine" ]] && tags+=($(sed -e 's/stable/latest/g' <<< $version))
     printf "%s %s %s %s n/a ${tags[*]-}\n" $(image_name "$version" "$distro") "n/a" "$distro" "$version"
-    if [[ ! -f "$distro/Dockerfile.docker-template" ]] ; then
-     continue
-    fi
     for docker_version in ${DOCKER_VERSIONS[*]} ; do
       printf "%s-docker-%s %s %s %s %s %s-docker-%s" \
         $(image_name "$version" "$distro") $docker_version \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -2,7 +2,6 @@ FROM krallin/ubuntu-tini:trusty
 MAINTAINER Tim Lucas <tim@buildkite.com>
 
 ARG BUILDKITE_AGENT_VERSION=stable
-ARG SSH_ENV_COMMIT_REF=bf7e6f0
 
 LABEL com.buildkite.distro="ubuntu" \
     com.buildkite.version=${BUILDKITE_AGENT_VERSION}


### PR DESCRIPTION
Currently ubuntu agent images build for all supported docker versions, but alpine uses the latest. This is due to needing alpine packages rather than using binaries like ubuntu does. This might be possible, but it's an experiment. 
