### PR TITLE
The ubuntu image should use the amd64 binary

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -16,7 +16,7 @@ ENV BUILDKITE_AGENT_VERSION=${BUILDKITE_AGENT_VERSION} \
     BUILDKITE_PLUGINS_PATH=/buildkite/plugins
 
 COPY ./scripts/docker/entrypoint.sh ./assets/ssh-env-config.sh /usr/local/bin/
-COPY ./assets/${BUILDKITE_AGENT_VERSION}-386 /buildkite
+COPY ./assets/${BUILDKITE_AGENT_VERSION}-amd64 /buildkite
 RUN ln -s /buildkite/buildkite-agent /usr/local/bin/buildkite-agent
 
 ENTRYPOINT ["/usr/local/bin/tini", "-vg", "--", "/usr/local/bin/entrypoint.sh", "buildkite-agent"]


### PR DESCRIPTION
The ubuntu images should use the amd64 binary, this was a copy-paste mistake. The alpine image still needs the 386 binary because of an outstanding issue with the wrong binary for edge being used. This replaces #30 which didn't work.
