### PR TITLE
Publish Alpine 1.9 images

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ Docker images for the [Buildkite Agent](https://github.com/buildkite/agent). A v
 
 At present we provide a variety of images based on Ubuntu or Alpine Linux base images, then with either the stable, beta or edge version of the Buildkite Agent, with or without docker:
 
- * `latest`, `alpine`, `ubuntu`, `ubuntu-docker-1.10`
- * `beta`, `beta-alpine`, `beta-ubuntu`, `beta-ubuntu-docker-1.10`
- * `edge`, `edge-alpine`, `edge-ubuntu`, `edge-ubuntu-docker-1.10`
+ * Stable agents: `latest`, `alpine`, `ubuntu`, `alpine-docker-1.11`, `ubuntu-docker-1.11`
+ * Beta agents: `beta`, `beta-alpine`, `beta-ubuntu`, `beta-alpine-docker-1.11`, `beta-ubuntu-docker-1.11`
+ * Experimental agents: `edge`, `edge-alpine`, `edge-ubuntu`, `edge-alpine-docker-1.11`, `edge-ubuntu-docker-1.11`
 
-If in doubt, go with `buildkite/agent:latest`, it's the smallest, the most stable and includes a docker client. Older versions of the docker images are built back to 1.6.2.
+If in doubt, go with `buildkite/agent:latest`, it's the smallest, the most stable and includes a docker client.
+
+For older versions of Docker (such as `1.9`) see the [complete tag list on Docker Hub](https://hub.docker.com/r/buildkite/agent/tags).
 
 ## Basic example
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -27,5 +27,5 @@ COPY ./scripts/docker/entrypoint.sh ./assets/ssh-env-config.sh /usr/local/bin/
 COPY ./assets/${BUILDKITE_AGENT_VERSION}-amd64 /buildkite
 RUN ln -s /buildkite/buildkite-agent /usr/local/bin/buildkite-agent
 
-ENTRYPOINT ["tini", "-vg", "--", "/usr/local/bin/entrypoint.sh", "buildkite-agent"]
+ENTRYPOINT ["tini", "-g", "--", "/usr/local/bin/entrypoint.sh", "buildkite-agent"]
 CMD ["start"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.4
 MAINTAINER Tim Lucas <tim@buildkite.com>
 
 ARG BUILDKITE_AGENT_VERSION=stable
@@ -14,7 +14,7 @@ LABEL com.buildkite.distro="alpine" \
     com.buildkite.docker_version=${DOCKER_VERSION} \
     com.buildkite.docker_compose_version=${DOCKER_COMPOSE_VERSION}
 
-RUN apk add --update --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ tini docker=${DOCKER_VERSION}-${ALPINE_DOCKER_REVISION} \
+RUN apk add --update --repository http://dl-cdn.alpinelinux.org/alpine/3.4/community/ docker=${DOCKER_VERSION}-${ALPINE_DOCKER_REVISION} \
     && apk add curl wget bash git perl openssh-client py-pip py-yaml \
     && pip install -U pip docker-compose==${DOCKER_COMPOSE_VERSION} \
     && rm -rf /tmp/* /root/.cache `find / -regex '.*\.py[co]'`
@@ -27,5 +27,5 @@ COPY ./scripts/docker/entrypoint.sh ./assets/ssh-env-config.sh /usr/local/bin/
 COPY ./assets/${BUILDKITE_AGENT_VERSION}-amd64 /buildkite
 RUN ln -s /buildkite/buildkite-agent /usr/local/bin/buildkite-agent
 
-ENTRYPOINT ["/usr/bin/tini", "-vg", "--", "/usr/local/bin/entrypoint.sh", "buildkite-agent"]
+ENTRYPOINT ["tini", "-vg", "--", "/usr/local/bin/entrypoint.sh", "buildkite-agent"]
 CMD ["start"]

--- a/alpine/Dockerfile-1.11
+++ b/alpine/Dockerfile-1.11
@@ -5,8 +5,7 @@ ARG BUILDKITE_AGENT_VERSION=stable
 ARG DOCKER_VERSION
 ARG DOCKER_COMPOSE_VERSION
 
-# Alpine sometimes has package revisions, check
-# https://pkgs.alpinelinux.org/packages?name=docker
+# See https://pkgs.alpinelinux.org/packages?name=docker
 ARG ALPINE_DOCKER_REVISION=r0
 
 LABEL com.buildkite.distro="alpine" \
@@ -14,8 +13,9 @@ LABEL com.buildkite.distro="alpine" \
     com.buildkite.docker_version=${DOCKER_VERSION} \
     com.buildkite.docker_compose_version=${DOCKER_COMPOSE_VERSION}
 
-RUN apk add --update --repository http://dl-cdn.alpinelinux.org/alpine/3.4/community/ docker=${DOCKER_VERSION}-${ALPINE_DOCKER_REVISION} \
-    && apk add curl wget bash git perl openssh-client py-pip py-yaml \
+RUN apk --no-cache add \
+      docker=${DOCKER_VERSION}-${ALPINE_DOCKER_REVISION} \
+      curl wget bash git perl openssh-client py-pip py-yaml \
     && pip install -U pip docker-compose==${DOCKER_COMPOSE_VERSION} \
     && rm -rf /tmp/* /root/.cache `find / -regex '.*\.py[co]'`
 

--- a/alpine/Dockerfile-1.11
+++ b/alpine/Dockerfile-1.11
@@ -13,6 +13,10 @@ LABEL com.buildkite.distro="alpine" \
     com.buildkite.docker_version=${DOCKER_VERSION} \
     com.buildkite.docker_compose_version=${DOCKER_COMPOSE_VERSION}
 
+# Install tini and remove its backwards compatibility wrapper
+RUN apk --no-cache add tini \
+    && rm /usr/bin/tini
+
 RUN apk --no-cache add \
       docker=${DOCKER_VERSION}-${ALPINE_DOCKER_REVISION} \
       curl wget bash git perl openssh-client py-pip py-yaml \

--- a/alpine/Dockerfile-1.9
+++ b/alpine/Dockerfile-1.9
@@ -1,0 +1,37 @@
+FROM alpine:3.3
+MAINTAINER Tim Lucas <tim@buildkite.com>
+
+ARG BUILDKITE_AGENT_VERSION=stable
+ARG DOCKER_VERSION
+ARG DOCKER_COMPOSE_VERSION
+
+# See https://pkgs.alpinelinux.org/packages?name=docker
+ARG ALPINE_DOCKER_REVISION=r2
+
+LABEL com.buildkite.distro="alpine" \
+    com.buildkite.version=${BUILDKITE_AGENT_VERSION} \
+    com.buildkite.docker_version=${DOCKER_VERSION} \
+    com.buildkite.docker_compose_version=${DOCKER_COMPOSE_VERSION}
+
+# Install tini and remove its backwards compatibility wrapper
+RUN apk --no-cache add \
+      --repository http://dl-cdn.alpinelinux.org/alpine/v3.4/community/ \
+      tini \
+    && rm /usr/bin/tini
+
+RUN apk --no-cache add \
+      docker=${DOCKER_VERSION}-${ALPINE_DOCKER_REVISION} \
+      curl wget bash git perl openssh-client py-pip py-yaml \
+    && pip install -U pip docker-compose==${DOCKER_COMPOSE_VERSION} \
+    && rm -rf /tmp/* /root/.cache `find / -regex '.*\.py[co]'`
+
+ENV BUILDKITE_AGENT_VERSION=${BUILDKITE_AGENT_VERSION} \
+    BUILDKITE_BUILD_PATH=/buildkite/builds \
+    BUILDKITE_HOOKS_PATH=/buildkite/hooks
+
+COPY ./scripts/docker/entrypoint.sh ./assets/ssh-env-config.sh /usr/local/bin/
+COPY ./assets/${BUILDKITE_AGENT_VERSION}-amd64 /buildkite
+RUN ln -s /buildkite/buildkite-agent /usr/local/bin/buildkite-agent
+
+ENTRYPOINT ["tini", "-g", "--", "/usr/local/bin/entrypoint.sh", "buildkite-agent"]
+CMD ["start"]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -63,15 +63,17 @@ scripts/list.sh | while read line ; do
   ## build base images (without docker)
   if [[ $docker == 'n/a' ]] ; then
     docker build \
-      --build-arg BUILDKITE_AGENT_VERSION=$version --tag "buildkite/agent:$tag" \
+      --build-arg BUILDKITE_AGENT_VERSION=$version \
+      --tag "buildkite/agent:$tag" \
       -f $distro/Dockerfile .
 
   ## build alpine image (with docker)
   elif [[ $distro == 'alpine' ]] ; then
     docker build \
-      --build-arg BUILDKITE_AGENT_VERSION=$version --tag "buildkite/agent:$tag" \
+      --build-arg BUILDKITE_AGENT_VERSION=$version \
       --build-arg DOCKER_VERSION=$docker \
       --build-arg DOCKER_COMPOSE_VERSION=$(docker_compose_version_from_docker $docker) \
+      --tag "buildkite/agent:$tag" \
       -f $distro/Dockerfile .
 
   # build variants with docker from Dockerfile.docker-template

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,6 +38,11 @@ docker_compose_version_from_docker() {
   fi
 }
 
+# Returns the major version for a given X.X.X docker version
+docker_major_version() {
+  cut -d. -f1-2 <<< $1
+}
+
 cd $(dirname $0)/../
 
 PATTERN=${1:-.+}
@@ -74,7 +79,7 @@ scripts/list.sh | while read line ; do
       --build-arg DOCKER_VERSION=$docker \
       --build-arg DOCKER_COMPOSE_VERSION=$(docker_compose_version_from_docker $docker) \
       --tag "buildkite/agent:$tag" \
-      -f $distro/Dockerfile .
+      -f "$distro/Dockerfile-$(docker_major_version $docker)" .
 
   # build variants with docker from Dockerfile.docker-template
   else

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,7 +28,7 @@ version_gt() {
 docker_compose_version_from_docker() {
   local docker_version="$1"
   if version_gt $docker_version "1.9.1" ; then
-    echo "1.7.0"
+    echo "1.7.1"
   elif version_gt $docker_version "1.7.1" ; then
     echo "1.5.2"
   elif version_gt $docker_version "1.7.0" ; then

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -24,4 +24,17 @@ if [[ -e /buildkite/bootstrap.sh ]] ; then
   export BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh
 fi
 
+if grep Ubuntu /etc/os-release > /dev/null; then
+  cat << EOF >&2
+---
+The Ubuntu versions of the buildkite/agent images are now deprecated and only
+the Alpine version of the images are supported and updated.
+
+Please migrate to the Alpine-based image, or if you’d like to use Ubuntu
+please build your own Docker image and use the standard Buildkite Agent
+installers.
+---
+EOF
+fi
+
 exec /usr/local/bin/ssh-env-config.sh "$@"

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -52,15 +52,7 @@ mkdir -p beta-amd64/
 tar xzvf beta-amd64.tar.gz -C beta-amd64/
 chmod +x beta-amd64/buildkite-agent
 
-rm -rf agent-master/
-download https://github.com/buildkite/agent/archive/master.zip master.zip
-unzip master.zip
-cd agent-master/
-docker build --tag agent-master .
-docker run -u "$(id -u)" --rm -v "$PWD:/go/src/github.com/buildkite/agent" agent-master scripts/utils/build-binary.sh "linux" "amd64" "edge"
-cd ../
-
 rm -rf edge-amd64/
 mkdir -p edge-amd64/
-cp agent-master/pkg/buildkite-agent-linux-amd64 edge-amd64/buildkite-agent
+download "https://download.buildkite.com/agent/experimental/latest/buildkite-agent-linux-amd64" edge-amd64/buildkite-agent
 chmod +x edge-amd64/buildkite-agent

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -19,5 +19,5 @@ COPY ./scripts/docker/entrypoint.sh ./assets/ssh-env-config.sh /usr/local/bin/
 COPY ./assets/${BUILDKITE_AGENT_VERSION}-amd64 /buildkite
 RUN ln -s /buildkite/buildkite-agent /usr/local/bin/buildkite-agent
 
-ENTRYPOINT ["/usr/local/bin/tini", "-vg", "--", "/usr/local/bin/entrypoint.sh", "buildkite-agent"]
+ENTRYPOINT ["tini", "-g", "--", "/usr/local/bin/entrypoint.sh", "buildkite-agent"]
 CMD ["start"]


### PR DESCRIPTION
The main aim of the PR is to fix #35 by publishing `alpine-docker-1.9` again (removed in #34), but it also includes the following changes:
- Update Docker Compose from 1.7.0 to 1.7.1
- Make `latest`/Alpine builds based on Alpine 3.4
- Reduces the `tini` verbosity
- Download the latest experimental agent build instead of building it from scratch

The `list.sh`/`build.sh` is getting a bit unwieldy with the differences in Ubuntu and Docker. I've unrolled some of the for looping in `list.sh` at the cost of some copy-pasta. The `list.sh`/`build.sh` dance is getting a little unwieldy.

The diff for `list.sh` looks like:

``` diff
< alpine n/a alpine stable 1.11.1 latest alpine-docker-1.11
< beta-alpine n/a alpine beta 1.11.1 beta beta-alpine-docker-1.11
< edge-alpine n/a alpine edge 1.11.1 edge edge-alpine-docker-1.11
> alpine-docker-1.9.1 n/a alpine stable 1.9.1 alpine-docker-1.9
> alpine-docker-1.11.1 n/a alpine stable 1.11.1 alpine-docker-1.11 latest alpine alpine-docker
> beta-alpine-docker-1.9.1 n/a alpine beta 1.9.1 beta-alpine-docker-1.9
> beta-alpine-docker-1.11.1 n/a alpine beta 1.11.1 beta-alpine-docker-1.11 beta beta-alpine beta-alpine-docker
> edge-alpine-docker-1.9.1 n/a alpine edge 1.9.1 edge-alpine-docker-1.9
> edge-alpine-docker-1.11.1 n/a alpine edge 1.11.1 edge-alpine-docker-1.11 edge edge-alpine edge-alpine-docker
```
