### PR TITLE
Don't hard-code the 2.x agent version

### DIFF
--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -13,21 +13,20 @@ RUN apk add --no-cache \
     py-pip \
     run-parts
 
-ENV BUILDKITE_AGENT_VERSION=2.4 \
-    BUILDKITE_BUILD_PATH=/buildkite/builds \
+ENV BUILDKITE_BUILD_PATH=/buildkite/builds \
     BUILDKITE_HOOKS_PATH=/buildkite/hooks \
     BUILDKITE_BOOTSTRAP_SCRIPT_PATH=/buildkite/bootstrap.sh
 
 RUN pip install docker-compose
 
-RUN curl -Lfs -o /usr/local/bin/buildkite-agent https://download.buildkite.com/agent/stable/${BUILDKITE_AGENT_VERSION}/buildkite-agent-linux-amd64 \
+RUN curl -Lfs -o /usr/local/bin/buildkite-agent https://download.buildkite.com/agent/stable/latest/buildkite-agent-linux-amd64 \
     && chmod +x /usr/local/bin/buildkite-agent \
     && mkdir -p /buildkite/builds /buildkite/hooks \
     && curl -Lfs -o /usr/local/bin/ssh-env-config.sh https://raw.githubusercontent.com/buildkite/docker-ssh-env-config/master/ssh-env-config.sh \
     && chmod +x /usr/local/bin/ssh-env-config.sh
 
 # In 3.0 this is built into the buildkite-agent binary
-RUN curl -Lfs -o /buildkite/bootstrap.sh https://raw.githubusercontent.com/buildkite/agent/v${BUILDKITE_AGENT_VERSION}/templates/bootstrap.sh \
+RUN curl -Lfs -o /buildkite/bootstrap.sh https://raw.githubusercontent.com/buildkite/agent/2-1-stable/templates/bootstrap.sh \
     && chmod +x /buildkite/bootstrap.sh
 
 COPY ./entrypoint.sh /usr/local/bin/buildkite-agent-entrypoint


### PR DESCRIPTION
This means we can have more automated Docker releases when there's new agent stable releases out.