### PR TITLE
Squash our final images

### DIFF
--- a/.buildkite/steps/release.sh
+++ b/.buildkite/steps/release.sh
@@ -21,7 +21,7 @@ tags=(beta edge stable)
 
 for tag in ${tags[*]} ; do
   echo "--- :docker: Building ${DOCKER_IMAGE}:${tag}"
-  docker build --tag "${DOCKER_IMAGE}:${tag}" -f "${tag}/Dockerfile" .
+  docker build --squash --tag "${DOCKER_IMAGE}:${tag}" -f "${tag}/Dockerfile" .
 done
 
 if [[ "$DOCKER_PUSH" =~ (true|1) ]]; then

--- a/.buildkite/steps/test.sh
+++ b/.buildkite/steps/test.sh
@@ -7,7 +7,7 @@ tags=(beta edge stable)
 
 for tag in ${tags[*]} ; do
   echo "--- :docker: Building ${DOCKER_IMAGE}:${tag}"
-  docker build --tag "${DOCKER_IMAGE}:${tag}" -f "${tag}/Dockerfile" .
+  docker build --squash --tag "${DOCKER_IMAGE}:${tag}" -f "${tag}/Dockerfile" .
 
   echo "--- :hammer: Testing ${DOCKER_IMAGE}:${tag} can run"
   docker run --rm --entrypoint "buildkite-agent" "${DOCKER_IMAGE}:${tag}" --version


### PR DESCRIPTION
The intermediate layers are useless to end users here, so we should probably just squash the final image.