### PR TITLE
Update versioning and secrets recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The Buildkite Agent is built on Alpine Linux, and available via the following do
 * `buildkite/agent:3` - 3.x releases (beta)
 * `buildkite/agent:edge` - Edge releases (master branch)
 
+The default tag (`buildkite/agent` and `buildkite/agent:latest`) currently points to `buildkite/agent:2`, but will be updated to `buildkite/agent:3` once it’s out of beta.
+
 You can also use the exact Buildkite Agent version tag if you want to make sure nothing changes, such as `buildkite/agent:3.0-beta.16`.
 
 Included in the image are `docker 1.13 (client)`, `docker-compose 1.10.0`, `tini`, `su-exec` and `jq`.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ docker run -it \
   buildkite/agent
 ```
 
-Alternatively, if you create your own image based off `buildkite/agent`, you can copy a hooks into the correct location:
+Alternatively, if you create your own image based off `buildkite/agent`, you can copy your hooks into the correct location:
 
 ```dockerfile
 FROM buildkite/agent
@@ -58,19 +58,17 @@ ADD hooks /buildkite/hooks/
 
 ## Exposing build secrets into the container
 
-There are many approaches to exposing secrets to Docker containers. In addition, many Docker platforms have their own method for exposing secrets.
+There are many approaches to exposing secrets to Docker containers. In addition, many Docker platforms have their own methods for exposing secrets. If you’re running your own Docker containers, we recommend using a read-only [host volume](https://docs.docker.com/engine/tutorials/dockervolumes/#mount-a-host-directory-as-a-data-volume).
 
-If you’re running your own Docker containers, we recommend using a read-only [host volume](https://docs.docker.com/engine/tutorials/dockervolumes/#mount-a-host-directory-as-a-data-volume).
-
-You can use the `environment` [agent hook](https://buildkite.com/docs/agent/hooks) to configure `git`, `ssh`, or export environment variables.
-
-For example, the following mounts the directory `$HOME/buildkite-secrets` from the host machine into the container at `/buildkite-secrets` (as read-only):
+The following example mounts a directory on the host machine containing secrets files (`$HOME/buildkite-secrets`) into the container at `/buildkite-secrets` as a read-only data volume:
 
 ```bash
 docker run -it \
   -v "$HOME/buildkite-secrets:/buildkite-secrets:ro" \
   buildkite/agent
 ```
+
+You can then use an `environment` [agent hook](https://buildkite.com/docs/agent/hooks) to expose those secrets via environment variables, or to configure tools such as `git` or `ssh`.
 
 ## Authenticating private git repositories
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker run -it \
 
 ## Configuring the agent
 
-Most [agent configuriation settings](https://buildkite.com/docs/agent/configuration) can be set with environment variables. Note: setting the agent token via an environment variable is not recommended as it is not secure (e.g. it will be exposed in `docker ps` commands).
+Most [agent configuration settings](https://buildkite.com/docs/agent/configuration) can be set with environment variables. Note: setting the agent token via an environment variable is not recommended as it is not secure (e.g. it will be exposed in `docker ps` commands).
 
 Alternatively, you can copy or mount a configuration file to `/buildkite/buildkite-agent.cfg`, for example:
 

--- a/README.md
+++ b/README.md
@@ -6,18 +6,20 @@ Docker images for the [Buildkite Agent](https://github.com/buildkite/agent).
 
 > If you don't need to run the agent on a purely Docker-based operating system (such as Kubernetes), and instead just want to [run your builds inside Docker containers](https://buildkite.com/docs/guides/docker-containerized-builds), then we recommend using one of the standard installers (such as `apt`). See the [containerized builds guide](https://buildkite.com/docs/guides/docker-containerized-builds) for more information.
 
-The Buildkite Agent is built on Alpine Linux, with either the stable, beta or experimental versions of the Buildkite Agent:
+The Buildkite Agent is built on Alpine Linux, and available via the following docker image tags:
 
- * Stable agents: `latest`, `stable`, `2`
- * Beta agents: `beta`, `3`
- * Latest master agents: `edge`
+* `buildkite/agent:2` - 2.x releases - Default (e.g. `buildkite/agent:latest`)
+* `buildkite/agent:3` - 3.x releases (beta)
+* `buildkite/agent:edge` - Edge releases (master branch)
 
-If in doubt, go with `buildkite/agent` — it's the most stable, and includes the docker client. Minor versions are also tagged, e.g `3.0-beta.16` if you want to make sure nothing changes. 
+You can also use the exact Buildkite Agent version tag if you want to make sure nothing changes, such as `buildkite/agent:3.0-beta.16`.
 
-Also included in the image are `docker 1.13 (client)`, `docker-compose 1.10.0`, `tini`, `su-exec` and `jq`.
+Included in the image are `docker 1.13 (client)`, `docker-compose 1.10.0`, `tini`, `su-exec` and `jq`.
+
+## Usage
 
 ```bash
-docker run buildkite/agent --help
+docker run buildkite/agent:2 --help
 ```
 
 ## Configuring the agent
@@ -29,7 +31,7 @@ In addition to environment variables, you can copy or mount a configuration file
 ```bash
 docker run -it \
   -v "$HOME/buildkite-agent.cfg:/buildkite/buildkite-agent.cfg:ro" \
-  buildkite/agent
+  buildkite/agent:2
 ```
 
 ## Adding hooks
@@ -41,7 +43,7 @@ For example, this is how you'd mount the hooks directory using a read-only host 
 ```bash
 docker run -it \
   -v "$HOME/buildkite-hooks:/buildkite-hooks:ro" \
-  buildkite/agent
+  buildkite/agent:2
 ```
 
 Alternatively, if you create your own image based off `buildkite/agent`, you can copy your hooks into the correct location:
@@ -61,7 +63,7 @@ The following example mounts a directory containing secrets on the host machine 
 ```bash
 docker run -it \
   -v "$HOME/buildkite-secrets:/buildkite-secrets:ro" \
-  buildkite/agent
+  buildkite/agent:2
 ```
 
 You can then use an `environment` [agent hook](https://buildkite.com/docs/agent/hooks) to expose those secrets via environment variables, or to configure tools such as `git` or `ssh`.
@@ -107,7 +109,7 @@ To invoke Docker from within builds you'll need to mount the Docker socket into 
 ```bash
 docker run -it \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  buildkite/agent
+  buildkite/agent:2
 ```
 
 Note that this gives builds the same access to the host system as docker has, which is generally root. 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@ docker run -it \
 
 ## Configuring the agent
 
-Almost all agent settings can be set with environment variables. Alternatively you can copy or mount a configuration file to `/buildkite/buildkite-agent.cfg`.
+Most [agent configuriation settings](https://buildkite.com/docs/agent/configuration) can be set with environment variables. Note: setting the agent token via an environment variable is not recommended as it is not secure (e.g. it will be exposed in `docker ps` commands).
+
+Alternatively, you can copy or mount a configuration file to `/buildkite/buildkite-agent.cfg`, for example:
+
+```bash
+docker run -it \
+  -v "$HOME/buildkite-agent.cfg:/buildkite/buildkite-agent.cfg:ro" \
+  buildkite/agent
+```
 
 ## Adding hooks
 

--- a/README.md
+++ b/README.md
@@ -16,19 +16,15 @@ If in doubt, go with `buildkite/agent` — it's the most stable, and includes th
 
 Also included in the image are `docker 1.13 (client)`, `docker-compose 1.10.0`, `tini`, `su-exec` and `jq`.
 
-## Basic example
-
 ```bash
-docker run -it \
-  -e BUILDKITE_AGENT_TOKEN=xxx \
-  buildkite/agent
+docker run buildkite/agent --help
 ```
 
 ## Configuring the agent
 
-Most [agent configuration settings](https://buildkite.com/docs/agent/configuration) can be set with environment variables. Setting the agent token this way _is not recommended_ as it will be exposed in `docker ps` commands.
+Most [agent configuration settings](https://buildkite.com/docs/agent/configuration) can be set with environment variables. Setting sensitive data, (such as the agent token) via environment variables or command line arguments _is not recommended_ as they are exposed in commands such as `docker inspect`.
 
-Alternatively, you can copy or mount a configuration file to `/buildkite/buildkite-agent.cfg`, for example:
+In addition to environment variables, you can copy or mount a configuration file to `/buildkite/buildkite-agent.cfg`, for example:
 
 ```bash
 docker run -it \
@@ -110,7 +106,6 @@ To invoke Docker from within builds you'll need to mount the Docker socket into 
 
 ```bash
 docker run -it \
-  -e BUILDKITE_AGENT_TOKEN=xxx \
   -v /var/run/docker.sock:/var/run/docker.sock \
   buildkite/agent
 ```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ You can then use an `environment` [agent hook](https://buildkite.com/docs/agent/
 
 To configure a [git-credentials file](https://git-scm.com/docs/git-credential-store#_storage_format) located at `/buildkite-secrets/git-credentials`, you could use the following `environment` [agent hook](https://buildkite.com/docs/agent/hooks) mounted to `/buildkite/hooks/environment`:
 
-```#!/bin/bash
+```bash
+#!/bin/bash
 
 set -euo pipefail
 
@@ -86,7 +87,8 @@ git config --global credential.helper "store --file=/buildkite-secrets/git-crede
 
 To configure a private SSH key located at `/buildkite-secrets/id_rsa_buildkite_git` you could use the following `environment` [agent hook](https://buildkite.com/docs/agent/hooks) mounted to `/buildkite/hooks/environment`:
 
-```#!/bin/bash
+```bash
+#!/bin/bash
 
 set -euo pipefail
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ ADD hooks /buildkite/hooks/
 
 There are many approaches to exposing secrets to Docker containers. In addition, many Docker platforms have their own methods for exposing secrets. If you’re running your own Docker containers, we recommend using a read-only [host volume](https://docs.docker.com/engine/tutorials/dockervolumes/#mount-a-host-directory-as-a-data-volume).
 
-The following example mounts a directory on the host machine containing secrets files (`$HOME/buildkite-secrets`) into the container at `/buildkite-secrets` as a read-only data volume:
+The following example mounts a directory containing secrets on the host machine (`$HOME/buildkite-secrets`) into the container as a read-only data volume at `/buildkite-secrets`:
 
 ```bash
 docker run -it \

--- a/README.md
+++ b/README.md
@@ -8,21 +8,25 @@ Docker images for the [Buildkite Agent](https://github.com/buildkite/agent).
 
 The Buildkite Agent is built on Alpine Linux, and available via the following docker image tags:
 
-* `buildkite/agent:2` - 2.x releases - Default (e.g. `buildkite/agent:latest`)
+* `buildkite/agent:2` - 2.x releases
 * `buildkite/agent:3` - 3.x releases (beta)
 * `buildkite/agent:edge` - Edge releases (master branch)
-
-The default tag (`buildkite/agent` and `buildkite/agent:latest`) currently points to `buildkite/agent:2`, but will be updated to `buildkite/agent:3` once it’s out of beta.
-
-You can also use the exact Buildkite Agent version tag if you want to make sure nothing changes, such as `buildkite/agent:3.0-beta.16`.
 
 Included in the image are `docker 1.13 (client)`, `docker-compose 1.10.0`, `tini`, `su-exec` and `jq`.
 
 ## Usage
 
 ```bash
-docker run buildkite/agent:2 --help
+docker run buildkite/agent:3 --help
 ```
+
+## Versioning
+
+The default tag (i.e. `buildkite/agent` and `buildkite/agent:latest`) will always point to the latest stable release (currently 2.x, but will change to 3.x once 3.0.0 is released).
+
+We recommend you use `buildkite/agent:3` for new setups.
+
+If you want to use an exact version of Buildkite Agent you can use the corresponding tag, such as `buildkite/agent:3.0-beta.16`.
 
 ## Configuring the agent
 
@@ -33,7 +37,7 @@ In addition to environment variables, you can copy or mount a configuration file
 ```bash
 docker run -it \
   -v "$HOME/buildkite-agent.cfg:/buildkite/buildkite-agent.cfg:ro" \
-  buildkite/agent:2
+  buildkite/agent:3
 ```
 
 ## Adding hooks
@@ -45,7 +49,7 @@ For example, this is how you'd mount the hooks directory using a read-only host 
 ```bash
 docker run -it \
   -v "$HOME/buildkite-hooks:/buildkite-hooks:ro" \
-  buildkite/agent:2
+  buildkite/agent:3
 ```
 
 Alternatively, if you create your own image based off `buildkite/agent`, you can copy your hooks into the correct location:
@@ -65,7 +69,7 @@ The following example mounts a directory containing secrets on the host machine 
 ```bash
 docker run -it \
   -v "$HOME/buildkite-secrets:/buildkite-secrets:ro" \
-  buildkite/agent:2
+  buildkite/agent:3
 ```
 
 You can then use an `environment` [agent hook](https://buildkite.com/docs/agent/hooks) to expose those secrets via environment variables, or to configure tools such as `git` or `ssh`.
@@ -111,7 +115,7 @@ To invoke Docker from within builds you'll need to mount the Docker socket into 
 ```bash
 docker run -it \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  buildkite/agent:2
+  buildkite/agent:3
 ```
 
 Note that this gives builds the same access to the host system as docker has, which is generally root. 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker run -it \
 
 ## Configuring the agent
 
-Most [agent configuration settings](https://buildkite.com/docs/agent/configuration) can be set with environment variables. Note: setting the agent token via an environment variable is not recommended as it is not secure (e.g. it will be exposed in `docker ps` commands).
+Most [agent configuration settings](https://buildkite.com/docs/agent/configuration) can be set with environment variables. Setting the agent token this way _is not recommended_ as it will be exposed in `docker ps` commands.
 
 Alternatively, you can copy or mount a configuration file to `/buildkite/buildkite-agent.cfg`, for example:
 


### PR DESCRIPTION
This updates the readme with the following:

* Move away from `beta/stable/edge` to `2/3/edge` — so people pin to the buildkite agent version they want, and ease the upgrade path for people.
* Adds more environment hook examples, based on people's feedback
* Updates the security recommendations, nudging people not to use environment variables and command line flags
* Includes a `git-credentials` file example in addition to an SSH key example
* Mentions the `tini` caveat that entrypoint files can't have file extensions