### PR TITLE
Bump to Alpine 3.6

### DIFF
--- a/beta/Dockerfile
+++ b/beta/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN apk add --no-cache \
     tini \

--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN apk add --no-cache \
     tini \

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN apk add --no-cache \
     tini \


### PR DESCRIPTION
This updates Alpine 3.6 and the base packages, so we can include a new Docker binary that works with things such as the current version of glcoud’s Kubernetes.