### PR TITLE
Fix Kubernetes 1.7 compatibility.

### DIFF
--- a/beta/Dockerfile
+++ b/beta/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache \
     jq \
     su-exec \
     py-pip \
+    libc6-compat \
     run-parts
 
 ENV BUILDKITE_BUILD_PATH=/buildkite/builds \

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache \
     jq \
     su-exec \
     py-pip \
+    libc6-compat \
     run-parts
 
 ENV BUILDKITE_BUILD_PATH=/buildkite/builds \


### PR DESCRIPTION
Add libc6-compat to Alpine-based image.

This fixes a surprising `No such file or directory` error when running certain binaries that do actually exist in the container. In particular, if you running buildkite-docker in Docker/Kubernetes `privileged: true` mode (so that it can spawn child docker containers) and you're mounting the `/usr/bin/docker` binary from the host (as recommended by the Buildkite docs), you will get a `No such file or directory` error and the build will die because it cannot execute the mounted docker binary from within the buildkite agent container. Adding libc6-compat fixes this.

These seems to affect Kubernetes >1.7, in both the buildkite-agent v2 and v3.