### PR TITLE
Add libc6-compat to Edge

### DIFF
--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache \
     jq \
     su-exec \
     py-pip \
+    libc6-compat \
     run-parts
 
 ENV BUILDKITE_BUILD_PATH=/buildkite/builds \


### PR DESCRIPTION
#60 missed adding the `libc6-compat` package to the edge images, so this adds it