### PR TITLE
Bump alpine image to 3.7

### DIFF
--- a/beta/Dockerfile
+++ b/beta/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
 RUN apk add --no-cache \
     tini \

--- a/edge/Dockerfile
+++ b/edge/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
 RUN apk add --no-cache \
     tini \

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
 RUN apk add --no-cache \
     tini \


### PR DESCRIPTION
Changes made by this pull request.
- Change base alpine image to use version 3.7

I did notice the conversation over at #59 regarding using the `latest` tag, I can modify if required.
The tests should be able to pick up if build breaks due to the alpine version, though it may make more sense just the pin the version and update manually as alpine is updated.

Alpine updates are not extremely frequent:
```
2017-11-30 Alpine 3.7.0 released
2017-06-17 Alpine 3.6.2 released
2017-06-01 Alpine 3.6.1 released
2017-05-24 Alpine 3.6.0 released
2017-03-02 Alpine 3.5.2 released
```